### PR TITLE
fix: add release signing config to Core Line build

### DIFF
--- a/ticker/android/app/build.gradle.kts
+++ b/ticker/android/app/build.gradle.kts
@@ -15,6 +15,18 @@ android {
         versionName = "1.0.0"
     }
 
+    signingConfigs {
+        create("release") {
+            val ksPath = System.getenv("KEYSTORE_PATH")
+            if (ksPath != null && file(ksPath).exists()) {
+                storeFile = file(ksPath)
+                storePassword = System.getenv("KEYSTORE_PASSWORD")
+                keyAlias = System.getenv("KEY_ALIAS")
+                keyPassword = System.getenv("KEY_PASSWORD")
+            }
+        }
+    }
+
     buildTypes {
         release {
             isMinifyEnabled = false
@@ -22,6 +34,10 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",
             )
+            val ks = System.getenv("KEYSTORE_PATH")
+            if (ks != null && file(ks).exists()) {
+                signingConfig = signingConfigs.getByName("release")
+            }
         }
     }
 


### PR DESCRIPTION
## Why this exists

The `coreline-v1.0.0` tag build failed because `build.gradle.kts` had no `signingConfigs` block — Gradle produced `app-release-unsigned.apk` and the signature verification step rejected it.

## What changed

1 file changed: `ticker/android/app/build.gradle.kts`

- Added `signingConfigs` block that reads `KEYSTORE_PATH`, `KEYSTORE_PASSWORD`, `KEY_ALIAS`, `KEY_PASSWORD` from environment variables (same pattern as the icon pack)
- Release build type conditionally uses the signing config when the keystore file exists

## Verification

- [x] Matches the icon pack's proven signing pattern in `app/build.gradle.kts`
- [x] Falls back to unsigned APK when env vars are not set (local dev still works)
- [x] No icon pack files touched

After merging, delete the `coreline-v1.0.0` tag and re-push it on the new main to retry the release.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJbpQkj9fcYQq4sLMHkjVQ)_