### PR TITLE
feat: stable Downloader URL for Core Line

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,3 +184,4 @@ jobs:
         with:
           files: app/build/outputs/apk/release/*.apk
           generate_release_notes: true
+          make_latest: true

--- a/.github/workflows/core-line-apk.yml
+++ b/.github/workflows/core-line-apk.yml
@@ -109,6 +109,15 @@ jobs:
           "$ANDROID_HOME/build-tools/34.0.0/apksigner" verify --print-certs "$APK"
           echo "APK signature verified."
 
+      - name: Name the APK for the stable Downloader URL
+        if: startsWith(github.ref, 'refs/tags/coreline-v')
+        run: |
+          SRC=$(ls ticker/android/app/build/outputs/apk/release/*.apk | grep -v unsigned | head -1)
+          mkdir -p dist
+          cp "$SRC" dist/coreline-release.apk
+          ls -lh dist/coreline-release.apk
+          echo "CORELINE_APK=$PWD/dist/coreline-release.apk" >> "$GITHUB_ENV"
+
       - name: Upload debug APK artifact
         if: ${{ !startsWith(github.ref, 'refs/tags/coreline-v') }}
         uses: actions/upload-artifact@v7
@@ -122,13 +131,35 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: CoreLine-release
-          path: ticker/android/app/build/outputs/apk/release/*.apk
+          path: dist/coreline-release.apk
           if-no-files-found: error
 
-      - name: Publish release
+      - name: Publish versioned release
         if: startsWith(github.ref, 'refs/tags/coreline-v')
         uses: softprops/action-gh-release@v3
         with:
-          files: ticker/android/app/build/outputs/apk/release/*.apk
+          files: dist/coreline-release.apk
           generate_release_notes: true
           name: "Core Line ${{ github.ref_name }}"
+          make_latest: false
+
+      - name: Point floating tag coreline at this commit
+        if: startsWith(github.ref, 'refs/tags/coreline-v')
+        run: |
+          git tag -f coreline "$GITHUB_SHA"
+          git push -f origin refs/tags/coreline
+
+      - name: Publish stable Downloader release
+        if: startsWith(github.ref, 'refs/tags/coreline-v')
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: coreline
+          name: Core Line (latest)
+          body: |
+            Always the current Core Line APK. Versioned notes live on `coreline-v*` releases.
+
+            Downloader (generate the numeric code **once** at https://go.aftvnews.com/):
+            https://github.com/brevityA/CoreBuildsApps/releases/download/coreline/coreline-release.apk
+          files: dist/coreline-release.apk
+          fail_on_unmatched_files: true
+          make_latest: false

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 > | App | What it does | Downloader | Release tag |
 > |---|---|---|---|
 > | **[Icon Pack](#-icon-pack)** | 516 transparent icons for Projectivy Launcher | `5270601` | [`v*`](../../releases) |
-> | **[Core Line](#-core-line)** | Sports scores & channel RSS ticker (chyron) | `TBD` | [`coreline-v*`](../../releases) |
+> | **[Core Line](#-core-line)** | Sports scores & channel RSS ticker (chyron) | [stable link](../../releases/tag/coreline) | [`coreline-v*`](../../releases) |
 >
 > Each app has its own CI workflow with path filters — changes to one never rebuild the other.
 
@@ -192,7 +192,9 @@ LIVE  TOR 3-2 MTL  ·  TSN4  SN 3     ◆     LAL vs BOS  7:00 PM  ·  ESPN
 
 ### Install
 
-1. Download using **Downloader code `TBD`**, or grab the APK from [**Releases**](../../releases) (tags starting with `coreline-v`).
+1. Grab the APK from the [**stable Downloader release**](../../releases/tag/coreline) (tags starting with `coreline-v` have versioned notes).
+   - **Stable URL:** `https://github.com/brevityA/CoreBuildsApps/releases/download/coreline/coreline-release.apk`
+   - Generate a Downloader code once at [go.aftvnews.com](https://go.aftvnews.com/) using the URL above.
 2. Sideload it (Downloader, `adb install`, or a file manager).
 3. Open the app — it loads a demo ticker immediately. Add your RSS feeds via the settings panel or pair from a phone on the same Wi-Fi using the QR code.
 
@@ -208,7 +210,7 @@ cd ticker/android && ./gradlew :app:assembleDebug
 
 Tests: `cd ticker && npm test` (24 tests).
 
-Release signing uses `CORELINE_KEYSTORE_BASE64`, `CORELINE_KEYSTORE_PASSWORD`, `CORELINE_KEY_ALIAS`, `CORELINE_KEY_PASSWORD` secrets.
+Release signing uses the same `KEYSTORE_BASE64`, `KEYSTORE_PASSWORD`, `KEY_ALIAS`, `KEY_PASSWORD` secrets as the icon pack.
 
 Full architecture and remaining debt: [`ticker/HANDOVER.md`](ticker/HANDOVER.md) · Detailed readme: [`ticker/README.md`](ticker/README.md).
 

--- a/ticker/android/github-workflow-core-line-apk.yml
+++ b/ticker/android/github-workflow-core-line-apk.yml
@@ -109,6 +109,15 @@ jobs:
           "$ANDROID_HOME/build-tools/34.0.0/apksigner" verify --print-certs "$APK"
           echo "APK signature verified."
 
+      - name: Name the APK for the stable Downloader URL
+        if: startsWith(github.ref, 'refs/tags/coreline-v')
+        run: |
+          SRC=$(ls ticker/android/app/build/outputs/apk/release/*.apk | grep -v unsigned | head -1)
+          mkdir -p dist
+          cp "$SRC" dist/coreline-release.apk
+          ls -lh dist/coreline-release.apk
+          echo "CORELINE_APK=$PWD/dist/coreline-release.apk" >> "$GITHUB_ENV"
+
       - name: Upload debug APK artifact
         if: ${{ !startsWith(github.ref, 'refs/tags/coreline-v') }}
         uses: actions/upload-artifact@v7
@@ -122,13 +131,35 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: CoreLine-release
-          path: ticker/android/app/build/outputs/apk/release/*.apk
+          path: dist/coreline-release.apk
           if-no-files-found: error
 
-      - name: Publish release
+      - name: Publish versioned release
         if: startsWith(github.ref, 'refs/tags/coreline-v')
         uses: softprops/action-gh-release@v3
         with:
-          files: ticker/android/app/build/outputs/apk/release/*.apk
+          files: dist/coreline-release.apk
           generate_release_notes: true
           name: "Core Line ${{ github.ref_name }}"
+          make_latest: false
+
+      - name: Point floating tag coreline at this commit
+        if: startsWith(github.ref, 'refs/tags/coreline-v')
+        run: |
+          git tag -f coreline "$GITHUB_SHA"
+          git push -f origin refs/tags/coreline
+
+      - name: Publish stable Downloader release
+        if: startsWith(github.ref, 'refs/tags/coreline-v')
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: coreline
+          name: Core Line (latest)
+          body: |
+            Always the current Core Line APK. Versioned notes live on `coreline-v*` releases.
+
+            Downloader (generate the numeric code **once** at https://go.aftvnews.com/):
+            https://github.com/brevityA/CoreBuildsApps/releases/download/coreline/coreline-release.apk
+          files: dist/coreline-release.apk
+          fail_on_unmatched_files: true
+          make_latest: false


### PR DESCRIPTION
## Why this exists

Both apps attach Gradle's default `app-release.apk`. GitHub's `/releases/latest/download/app-release.apk` resolves to whichever release was published last, so a Downloader code on that URL silently installs the wrong app when the other app tags a newer release.

Core Line needs a stable URL that never changes between releases and never collides with the icon pack.

## What changed

- `.github/workflows/core-line-apk.yml` — rename release APK to `coreline-release.apk`, add floating `coreline` tag that CI force-moves on every release, publish a stable release on that tag for a permanent Downloader URL, set `make_latest: false` on Core Line releases
- `.github/workflows/build.yml` — set `make_latest: true` on icon pack releases so GitHub Latest stays the icon pack
- `README.md` — replace `TBD` Downloader placeholder with stable URL, fix stale `CORELINE_*` secret names
- `ticker/android/github-workflow-core-line-apk.yml` — synced reference copy

**Stable Downloader URL (generate the numeric code once at https://go.aftvnews.com/):**
```
https://github.com/brevityA/CoreBuildsApps/releases/download/coreline/coreline-release.apk
```

## Verification

- [x] Versioned `coreline-v*` releases use `make_latest: false`
- [x] Icon pack `v*` releases use `make_latest: true`
- [x] Floating `coreline` tag force-moved by CI on every release
- [x] Stable release on `coreline` tag holds `coreline-release.apk`
- [x] No new secrets — signing uses existing `KEYSTORE_*` secrets
- [x] Both workflow files kept in sync


---
_Generated by [Claude Code](https://claude.ai/code/session_01RJbpQkj9fcYQq4sLMHkjVQ)_