### PR TITLE
chore: bump Core Line to v1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ ticker/                      Core Line — sports & channel ticker (see ticker/R
 
 ## 🔷 Core Line
 
-**TV-first sports & channel ticker (chyron).** `v1.0.0`
+**TV-first sports & channel ticker (chyron).** `v1.0.1`
 
 Not a player, not a playlist, not streams — a reader that crawls the listings other channel apps already publish as RSS:
 

--- a/ticker/android/app/build.gradle.kts
+++ b/ticker/android/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
         applicationId = "dev.corebuilds.line"
         minSdk = 24
         targetSdk = 34
-        versionCode = 1
-        versionName = "1.0.0"
+        versionCode = 2
+        versionName = "1.0.1"
     }
 
     signingConfigs {


### PR DESCRIPTION
## Why this exists

Bumps Core Line version so the next tag (`coreline-v1.0.1`) triggers the new stable Downloader workflow from PR #23.

## What changed

- `ticker/android/app/build.gradle.kts` — versionCode 1 → 2, versionName 1.0.0 → 1.0.1
- `README.md` — version label updated

## Verification

- [x] versionCode incremented
- [x] versionName matches intended tag `coreline-v1.0.1`


---
_Generated by [Claude Code](https://claude.ai/code/session_01RJbpQkj9fcYQq4sLMHkjVQ)_