### PR TITLE
chore: bump Core Line to v1.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ ticker/                      Core Line — sports & channel ticker (see ticker/R
 
 ## 🔷 Core Line
 
-**TV-first sports & channel ticker (chyron).** `v1.0.1`
+**TV-first sports & channel ticker (chyron).** `v1.0.2`
 
 Not a player, not a playlist, not streams — a reader that crawls the listings other channel apps already publish as RSS:
 

--- a/ticker/android/app/build.gradle.kts
+++ b/ticker/android/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
         applicationId = "dev.corebuilds.line"
         minSdk = 24
         targetSdk = 34
-        versionCode = 2
-        versionName = "1.0.1"
+        versionCode = 3
+        versionName = "1.0.2"
     }
 
     signingConfigs {


### PR DESCRIPTION
## Summary

- Bumps `versionCode` 2 → 3 and `versionName` "1.0.1" → "1.0.2" in `ticker/android/app/build.gradle.kts`
- Updates README Core Line version to v1.0.2

After merge, tag `coreline-v1.0.2` on main to trigger the release build.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJbpQkj9fcYQq4sLMHkjVQ)_