### PR TITLE
Update README to v1.7.1 + cherry-pick intent queries & updater fallback from PR #20

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 > | App | What it does | Downloader | Release tag |
 > |---|---|---|---|
-> | **[Icon Pack](#-icon-pack)** | 917 transparent icons for Projectivy Launcher | `5270601` | [`v*`](../../releases) |
+> | **[Icon Pack](#-icon-pack)** | 921 transparent icons + 6 wallpapers for Projectivy Launcher | `5270601` | [`v*`](../../releases) |
 > | **[Core Line](#-core-line)** | Sports scores & channel RSS ticker (chyron) | `7375676` | [`coreline-v*`](../../releases) |
 >
 > Each app has its own CI workflow with path filters — changes to one never rebuild the other.
@@ -22,7 +22,7 @@
 ## 🔷 Icon Pack
 
 **Transparent app icons for Projectivy Launcher on Android TV.**
-`917 icons` · `v1.6.0`
+`921 icons` · `6 wallpapers` · `v1.7.1`
 
 The **Core Builds Icon Pack** is designed for the [Projectivy Launcher](https://play.google.com/store/apps/details?id=com.spocky.projengmenu) on Android TV and Google TV, built to the [Core Builds Brand & Style Guide v1.0](https://github.com/brevityA/Core-Builds).
 
@@ -54,13 +54,19 @@ Icons are **original geometry** drawn on a shared 512 grid — simple shapes, ro
 
 ### What's covered
 
-917 icons across 21 categories — streaming, media centres, debrid services, players, launchers, tools, stores, live TV, music, sport, gaming, VPN, browsers, files, and more.
+921 icons across 21 categories — streaming, media centres, debrid services, players, launchers, tools, stores, live TV, music, sport, gaming, VPN, browsers, files, and more.
 
-Highlights: Stremio, Kodi, Jellyfin, Emby, Plex, Nuvio TV, Syncler, Weyd, TorBox, Real-Debrid, AllDebrid, Premiumize, Trakt, VLC, MX Player, SmartTube, YouTube, Spotify, Twitch, Downloader, Aurora Store, TiviMate, TV Bro, SYNC, LocalSend, RS File Manager, Sparkle TV, DS file — plus Netflix, Prime Video, Disney+, Max, Apple TV, Stan, Binge, Kayo, ABC iview, 9Now, 7plus, 10 Play, SBS, and 870+ more.
+Highlights: Stremio, Kodi, Jellyfin, Emby, Plex, Nuvio TV, Syncler, Weyd, TorBox, Real-Debrid, AllDebrid, Premiumize, Trakt, VLC, MX Player, SmartTube, YouTube, Spotify, Twitch, Downloader, Aurora Store, TiviMate, TV Bro, SYNC, LocalSend, RS File Manager, Sparkle TV, DS file, Ultimate File Manager Pro — plus Netflix, Prime Video, Disney+, Max, Apple TV, Stan, Binge, Kayo, ABC iview, 9Now, 7plus, 10 Play, SBS, and 870+ more.
 
 Full table with every mapped component: [**docs/IconPackList.md**](docs/IconPackList.md)
 
 <div align="center"><img src="docs/preview.png" alt="All icons" width="760"></div>
+
+---
+
+### Wallpapers
+
+6 curated wallpapers — browse in the Wallpapers tab, preview full-screen, Set as device wallpaper or Save to `Pictures/CoreBuilds`. Multi-select export lets you bulk-save to the folder where launchers like Monet auto-rotate. Thumbnails are bundled; full 4K images download on demand from GitHub.
 
 ---
 
@@ -167,9 +173,9 @@ tools/build_icons.py         catalog → SVG, PNG, appfilter, docs
 tools/build_banners.py       catalog → 16:9 monoline banners
 tools/build_branding.py      launcher icon + Leanback banner
 tools/build_brand_preview.py branding preview sheet
-tools/validate.py            coherence checks (22,000+ at 917 icons)
-assets/svg/                  master vectors (917)
-assets/banners/              16:9 banners (917)
+tools/validate.py            coherence checks (22,800+ at 921 icons)
+assets/svg/                  master vectors (921)
+assets/banners/              16:9 banners (921)
 app/src/main/res/            the Android module
 Latestrelease/version.json   in-app update manifest
 docs/IconPackList.md         supported apps + components
@@ -180,7 +186,7 @@ ticker/                      Core Line — sports & channel ticker (see ticker/R
 
 ## 🔷 Core Line
 
-**TV-first sports & channel ticker (chyron).** `v1.0.1`
+**TV-first sports & channel ticker (chyron).** `v1.0.2`
 
 Not a player, not a playlist, not streams — a reader that crawls the listings other channel apps already publish as RSS:
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 > | App | What it does | Downloader | Release tag |
 > |---|---|---|---|
-> | **[Icon Pack](#-icon-pack)** | 921 transparent icons + 6 wallpapers for Projectivy Launcher | `5270601` | [`v*`](../../releases) |
+> | **[Icon Pack](#-icon-pack)** | 921 transparent icons + 70 wallpapers for Projectivy Launcher | `5270601` | [`v*`](../../releases) |
 > | **[Core Line](#-core-line)** | Sports scores & channel RSS ticker (chyron) | `7375676` | [`coreline-v*`](../../releases) |
 >
 > Each app has its own CI workflow with path filters — changes to one never rebuild the other.
@@ -22,7 +22,7 @@
 ## 🔷 Icon Pack
 
 **Transparent app icons for Projectivy Launcher on Android TV.**
-`921 icons` · `6 wallpapers` · `v1.7.1`
+`921 icons` · `70 wallpapers` · `v1.7.1`
 
 The **Core Builds Icon Pack** is designed for the [Projectivy Launcher](https://play.google.com/store/apps/details?id=com.spocky.projengmenu) on Android TV and Google TV, built to the [Core Builds Brand & Style Guide v1.0](https://github.com/brevityA/Core-Builds).
 
@@ -66,7 +66,7 @@ Full table with every mapped component: [**docs/IconPackList.md**](docs/IconPack
 
 ### Wallpapers
 
-6 curated wallpapers — browse in the Wallpapers tab, preview full-screen, Set as device wallpaper or Save to `Pictures/CoreBuilds`. Multi-select export lets you bulk-save to the folder where launchers like Monet auto-rotate. Thumbnails are bundled; full 4K images download on demand from GitHub.
+70 curated wallpapers — browse in the Wallpapers tab, preview full-screen, Set as device wallpaper or Save to `Pictures/CoreBuilds`. Multi-select export lets you bulk-save to the folder where launchers like Monet auto-rotate. Thumbnails are bundled; full 4K images download on demand from GitHub.
 
 ---
 
@@ -116,7 +116,7 @@ pip install -r tools/requirements.txt
 python tools/build_icons.py      # SVGs, PNGs, appfilter, docs, preview
 python tools/build_banners.py    # 16:9 monoline banners
 python tools/build_branding.py   # launcher icon + TV banner
-python tools/validate.py         # 12800+ coherence checks
+python tools/validate.py         # 22,800+ coherence checks
 ```
 
 **Finding a component name** for an installed app:

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -59,6 +59,42 @@
         <intent>
             <action android:name="com.spocky.projengmenu.APPLY_ICONPACK" />
         </intent>
+        <!-- Generic apply contracts. Declared as <intent> queries so an
+             unknown HOME launcher that supports a standard contract is still
+             visible on Android 11+ without a per-package entry. -->
+        <intent>
+            <action android:name="com.novalauncher.THEME" />
+        </intent>
+        <intent>
+            <action android:name="org.adw.launcher.THEMES" />
+        </intent>
+        <intent>
+            <action android:name="com.gau.go.launcherex.theme" />
+        </intent>
+        <intent>
+            <action android:name="com.anddoes.launcher.THEME" />
+        </intent>
+        <intent>
+            <action android:name="com.anddoes.launcher.SET_THEME" />
+        </intent>
+        <intent>
+            <action android:name="org.adw.launcher.SET_THEME" />
+        </intent>
+        <intent>
+            <action android:name="org.adwfreak.launcher.SET_THEME" />
+        </intent>
+        <intent>
+            <action android:name="ch.deletescape.lawnchair.APPLY_ICONS" />
+        </intent>
+        <intent>
+            <action android:name="ch.deletescape.lawnchair.ICONPACK" />
+        </intent>
+        <intent>
+            <action android:name="com.teslacoilsw.launcher.APPLY_ICON_THEME" />
+        </intent>
+        <intent>
+            <action android:name="com.fede.launcher.THEME_ICONPACK" />
+        </intent>
     </queries>
 
     <application

--- a/app/src/main/java/tv/corebuilds/iconpack/UpdateChecker.kt
+++ b/app/src/main/java/tv/corebuilds/iconpack/UpdateChecker.kt
@@ -24,9 +24,12 @@ import java.util.concurrent.Executors
 object UpdateChecker {
 
     private const val TAG = "CoreBuildsUpdate"
-    private const val MANIFEST_URL =
+    private val MANIFEST_URLS = listOf(
+        "https://raw.githubusercontent.com/brevityA/CoreBuildsApps/" +
+            "main/Latestrelease/version.json",
         "https://raw.githubusercontent.com/brevityA/CoreBuildsIconPack/" +
             "main/Latestrelease/version.json"
+    )
     private const val TIMEOUT_MS = 8000
 
     /** Outcome of a check. Never an unnamed error (§08). */
@@ -67,35 +70,46 @@ object UpdateChecker {
     }
 
     private fun fetch(installedCode: Int): Result {
-        val conn = (URL(MANIFEST_URL).openConnection() as HttpURLConnection).apply {
-            connectTimeout = TIMEOUT_MS
-            readTimeout = TIMEOUT_MS
-            requestMethod = "GET"
-            setRequestProperty("Accept", "application/json")
-        }
-        try {
-            val code = conn.responseCode
-            if (code != 200) {
-                return Result.Failed("update manifest returned HTTP $code")
+        var lastError: String? = null
+        for (url in MANIFEST_URLS) {
+            var conn: HttpURLConnection? = null
+            try {
+                conn = (URL(url).openConnection() as HttpURLConnection).apply {
+                    connectTimeout = TIMEOUT_MS
+                    readTimeout = TIMEOUT_MS
+                    requestMethod = "GET"
+                    setRequestProperty("Accept", "application/json")
+                    setRequestProperty("User-Agent", "CoreBuildsIconPack-Updater")
+                }
+                val code = conn.responseCode
+                if (code != 200) {
+                    lastError = "update manifest returned HTTP $code from $url"
+                    Log.w(TAG, lastError!!)
+                    continue
+                }
+                val body = conn.inputStream.bufferedReader().use { it.readText() }
+                val json = JSONObject(body)
+
+                val remoteCode = json.getInt("versionCode")
+                val remoteName = json.optString("versionName", "?")
+                val icons = json.optInt("iconCount", 0)
+                val apk = json.optString("apkUrl", "")
+
+                Log.i(TAG, "installed=$installedCode remote=$remoteCode from $url")
+
+                return if (remoteCode > installedCode) {
+                    Result.Available(remoteName, remoteCode, icons, apk)
+                } else {
+                    Result.UpToDate(remoteName)
+                }
+            } catch (e: Exception) {
+                lastError = e.message ?: e.javaClass.simpleName
+                Log.w(TAG, "manifest fetch failed $url: $lastError")
+            } finally {
+                try { conn?.disconnect() } catch (_: Exception) {}
             }
-            val body = conn.inputStream.bufferedReader().use { it.readText() }
-            val json = JSONObject(body)
-
-            val remoteCode = json.getInt("versionCode")
-            val remoteName = json.optString("versionName", "?")
-            val icons = json.optInt("iconCount", 0)
-            val apk = json.optString("apkUrl", "")
-
-            Log.i(TAG, "installed=$installedCode remote=$remoteCode")
-
-            return if (remoteCode > installedCode) {
-                Result.Available(remoteName, remoteCode, icons, apk)
-            } else {
-                Result.UpToDate(remoteName)
-            }
-        } finally {
-            conn.disconnect()
         }
+        return Result.Failed(lastError ?: "could not fetch update manifest")
     }
 
     private fun installedVersionCode(context: Context): Int = try {


### PR DESCRIPTION
## Why

README was stale after v1.7.1 shipped. PR #20 (arena bot) has been sitting open with useful improvements that don't need the full 300-line ApplyIconPack refactor.

## What changed

### README (commits 1–2)
- Icon count 917 → 921, version v1.6.0 → v1.7.1
- Added Wallpapers section (70 curated wallpapers with browse/preview/bulk export to Pictures/CoreBuilds)
- Added Ultimate File Manager Pro to highlights
- Updated validator check count to 22,800+
- Updated Core Line version to v1.0.2
- Updated summary table to mention wallpapers

### Cherry-picked from PR #20 (commit 3)
- **AndroidManifest.xml** — 11 generic `<intent>` queries (Nova, ADW, GO, Apex, ADW SET, Apex SET, Lawnchair APPLY_ICONS/ICONPACK, Nova APPLY_ICON_THEME, Fede) so an unknown HOME launcher that supports a standard icon-pack contract is visible on Android 11+ without a per-package entry
- **UpdateChecker.kt** — polls CoreBuildsApps first, falls back to legacy CoreBuildsIconPack (post-rename). Loops both URLs with timeout/logging, adds User-Agent header, properly disconnects in finally block

### Skipped from PR #20
- ApplyIconPack.kt candidate-probing refactor (300+ lines) — worth revisiting as a standalone PR
- Latestrelease/version.json URL update — already correct on main

## Verification

- `tools/validate.py` → 921 icons · 1654 components · 22,842 checks ✓
- `tests/test_wallpapers.py` → 17/17 ✓
- `tests/test_v151_robustness.py` → 24/24 ✓