### PR TITLE
fix(shift): Core Shift v2.0.1 — D-pad button hot patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ Full architecture and remaining debt: [`ticker/HANDOVER.md`](ticker/HANDOVER.md)
 
 ## 🔷 Core Shift
 
-**Live wallpaper browser + Projectivy plugin for Monet Launcher.** `v2.0.0`
+**Live wallpaper browser + Projectivy plugin for Monet Launcher.** `v2.0.1`
 
 Two delivery paths for motion wallpapers on Android TV:
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Core Builds Apps
 
-**Two Android TV apps. Same brand, same living-room bar.**
+**Three Android TV apps. Same brand, same living-room bar.**
 
 </div>
 
@@ -14,8 +14,9 @@
 > |---|---|---|---|
 > | **[Icon Pack](#-icon-pack)** | 921 transparent icons + 70 wallpapers for Projectivy Launcher | `5270601` | [`v*`](../../releases) |
 > | **[Core Line](#-core-line)** | Sports scores & channel RSS ticker (chyron) | `7375676` | [`coreline-v*`](../../releases) |
+> | **[Core Shift](#-core-shift)** | Live wallpaper browser + Projectivy plugin for Monet Launcher | `8829421` | [`shift-v*`](../../releases) |
 >
-> Each app has its own CI workflow with path filters — changes to one never rebuild the other.
+> Each app has its own CI workflow — changes to one never rebuild the others.
 
 ---
 
@@ -180,6 +181,10 @@ app/src/main/res/            the Android module
 Latestrelease/version.json   in-app update manifest
 docs/IconPackList.md         supported apps + components
 ticker/                      Core Line — sports & channel ticker (see ticker/README.md)
+shift/                       Core Shift — live wallpaper browser (see shift/HANDOVER.md)
+motion-plugin/               Core Motion — Projectivy wallpaper-provider plugin
+motion-shaders/              GLSL fragment shaders (hex plasma, starfield, flow)
+Motion/live/                 Motion asset set (MP4 loops, thumbnails, live-feed.json)
 ```
 
 ---
@@ -221,6 +226,50 @@ Tests: `cd ticker && npm test` (24 tests).
 Release signing uses the same `KEYSTORE_BASE64`, `KEYSTORE_PASSWORD`, `KEY_ALIAS`, `KEY_PASSWORD` secrets as the icon pack.
 
 Full architecture and remaining debt: [`ticker/HANDOVER.md`](ticker/HANDOVER.md) · Detailed readme: [`ticker/README.md`](ticker/README.md).
+
+---
+
+## 🔷 Core Shift
+
+**Live wallpaper browser + Projectivy plugin for Monet Launcher.** `v2.0.0`
+
+Two delivery paths for motion wallpapers on Android TV:
+
+- **Monet Launcher** — browse live wallpapers in-app, full-screen looping preview, download MP4 loops to `Movies/CoreBuilds`. Point Monet Premium's video wallpaper picker at that folder.
+- **Projectivy Launcher** — the **Core Motion** plugin (`motion-plugin/`, `tv.corebuilds.motion`) implements Spocky's `IWallpaperProviderService` AIDL. Serves an Overflight-compatible JSON feed as `VIDEO` wallpapers plus bundled Lottie vector loops. Sideload the plugin APK → Settings → Appearance → Wallpaper → Core Motion.
+
+Content pipeline: 10 ffmpeg-filter MP4 loops (1080p H.264), 3 self-authored GLSL shaders (hex plasma, starfield, flowing noise), and bundled Lottie vectors — all §03 palette.
+
+- HTTPS-only downloads with GitHub host allowlist
+- Leanback UI built for D-pad navigation
+- Remote manifest with bundled fallback — works offline after first sync
+- CI-validated motion asset set
+
+### Install
+
+1. Download using **Downloader code `8829421`**, or use the permanent APK URL:
+
+   **https://github.com/brevityA/CoreBuildsApps/releases/download/shift/coreshift-release.apk**
+
+   Versioned builds remain available from [**Releases**](../../releases) under `shift-v*` tags. The `shift` release is a floating stable target.
+2. Sideload it (Downloader, `adb install`, or a file manager).
+3. Open the app — browse live wallpapers, preview full-screen, and download to `Movies/CoreBuilds` for Monet.
+
+### Building
+
+CI: [`.github/workflows/core-shift-apk.yml`](.github/workflows/core-shift-apk.yml) → push a `shift-v*` tag to cut a release. Debug APKs are uploaded as CI artifacts on pushes to `main` and matching pull requests.
+
+Locally (needs JDK 17 + Android SDK):
+
+```bash
+cd shift && ./gradlew :app:assembleDebug
+```
+
+Motion asset validation: `python tools/validate_motion_feed.py`.
+
+Release signing uses the same `KEYSTORE_BASE64`, `KEYSTORE_PASSWORD`, `KEY_ALIAS`, `KEY_PASSWORD` secrets as the icon pack and Core Line.
+
+Full architecture and remaining debt: [`shift/HANDOVER.md`](shift/HANDOVER.md).
 
 ---
 

--- a/shift/app/build.gradle.kts
+++ b/shift/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
         applicationId = "dev.corebuilds.shift"
         minSdk = 26
         targetSdk = 34
-        versionCode = 2
-        versionName = "2.0.0"
+        versionCode = 3
+        versionName = "2.0.1"
     }
 
     signingConfigs {

--- a/shift/app/src/main/res/color/btn_text.xml
+++ b/shift/app/src/main/res/color/btn_text.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_focused="true" android:color="@color/cb_night" />
+    <item android:state_enabled="false" android:color="@color/cb_text_secondary" />
+    <item android:color="@color/cb_text_primary" />
+</selector>

--- a/shift/app/src/main/res/drawable/btn_bg.xml
+++ b/shift/app/src/main/res/drawable/btn_bg.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_focused="true">
+        <shape>
+            <solid android:color="@color/cb_cyan" />
+            <corners android:radius="6dp" />
+        </shape>
+    </item>
+    <item android:state_enabled="false">
+        <shape>
+            <solid android:color="#1B2634" />
+            <corners android:radius="6dp" />
+        </shape>
+    </item>
+    <item>
+        <shape>
+            <solid android:color="#1B2634" />
+            <stroke android:width="1dp" android:color="@color/cb_text_secondary" />
+            <corners android:radius="6dp" />
+        </shape>
+    </item>
+</selector>

--- a/shift/app/src/main/res/layout/item_live.xml
+++ b/shift/app/src/main/res/layout/item_live.xml
@@ -58,7 +58,11 @@
             android:layout_height="wrap_content"
             android:minWidth="120dp"
             android:text="@string/preview"
-            android:textSize="16sp" />
+            android:textSize="16sp"
+            android:textColor="@color/btn_text"
+            android:background="@drawable/btn_bg"
+            android:focusable="true"
+            android:nextFocusDown="@id/btn_download" />
 
         <Button
             android:id="@+id/btn_download"
@@ -66,6 +70,10 @@
             android:layout_height="wrap_content"
             android:minWidth="120dp"
             android:text="@string/download"
-            android:textSize="16sp" />
+            android:textSize="16sp"
+            android:textColor="@color/btn_text"
+            android:background="@drawable/btn_bg"
+            android:focusable="true"
+            android:nextFocusUp="@id/btn_preview" />
     </LinearLayout>
 </LinearLayout>

--- a/shift/app/src/main/res/layout/item_live.xml
+++ b/shift/app/src/main/res/layout/item_live.xml
@@ -7,7 +7,7 @@
     android:padding="12dp"
     android:layout_marginBottom="8dp"
     android:background="@drawable/card_bg"
-    android:focusable="true">
+    android:descendantFocusability="afterDescendants">
 
     <ImageView
         android:id="@+id/thumb"


### PR DESCRIPTION
## Why this exists

Preview and Download buttons in Core Shift were unreachable by D-pad on Android TV. The row container's `focusable="true"` intercepted focus, so remote users couldn't navigate to or activate either button.

## What changed

- `shift/app/src/main/res/layout/item_live.xml` — removed `focusable` from row container, added `descendantFocusability="afterDescendants"`, made buttons explicitly focusable with `nextFocusDown`/`nextFocusUp` navigation and focus-aware drawables
- `shift/app/src/main/res/drawable/btn_bg.xml` (new) — state-list background: cyan fill on focus, dark idle with subtle border, dim disabled
- `shift/app/src/main/res/color/btn_text.xml` (new) — state-list text color: dark on focused cyan, light otherwise
- `shift/app/build.gradle.kts` — versionCode 2→3, versionName 2.0.0→2.0.1
- `README.md` — Core Shift section added (v2.0.0→v2.0.1), repo layout updated

## Verification

- [ ] No Android SDK in this environment — APK build not attempted
- [x] Layout XML, drawable, and color resources are valid Android resource files
- [x] Focus navigation chain verified: btn_preview ↔ btn_download via nextFocusDown/nextFocusUp
- [x] Version bump consistent across build.gradle.kts and README