### PR TITLE
feat(shift+motion): in-app updater, Core Motion detection fix, Monet route, list motion

### DIFF
--- a/.github/workflows/core-motion-apk.yml
+++ b/.github/workflows/core-motion-apk.yml
@@ -19,7 +19,9 @@ on:
     paths:
       - 'motion-plugin/**'
       - 'Motion/live-feed.json'
+      - 'Motion/aerial-entries.json'
       - 'tools/verify_motion_plugin.py'
+      - 'tools/build_aerial_feed.py'
       - '.github/workflows/core-motion-apk.yml'
   push:
     branches: [main]
@@ -44,6 +46,12 @@ jobs:
       # A silent drift here is exactly what makes a plugin undetectable.
       - name: Verify Projectivy plugin contract
         run: python tools/verify_motion_plugin.py
+
+      # Monet Launcher has no plugin API; the supported route onto Monet is
+      # Aerial Views' custom-feed format. That feed is a projection of
+      # live-feed.json, so it must never drift. See docs/MONET_LAUNCHER.md.
+      - name: Verify the Aerial Views bridge feed is in sync
+        run: python tools/build_aerial_feed.py --check
 
   apk:
     name: Assemble plugin APK

--- a/.github/workflows/core-motion-apk.yml
+++ b/.github/workflows/core-motion-apk.yml
@@ -1,0 +1,206 @@
+name: Core Motion APK
+
+# Builds the Core Motion Projectivy wallpaper-provider plugin (motion-plugin/).
+#
+# This is the piece that was missing: the plugin has a full source tree and a
+# README that says "sideload the APK", but nothing ever built one, so there was
+# never anything for Projectivy to detect. See docs/PROJECTIVY_DETECTION.md.
+#
+# The plugin is a standalone Gradle root (motion-plugin/settings.gradle.kts),
+# same as shift/ and separate from the icon pack.
+#
+# CI:      push/PR touching motion-plugin/** or the feed → verify + debug APK
+# Release: push a motion-v* tag → verify + signed release APK → GitHub Release
+#          plus a force-moved floating `motion` tag for a stable Downloader URL.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'motion-plugin/**'
+      - 'Motion/live-feed.json'
+      - 'tools/verify_motion_plugin.py'
+      - '.github/workflows/core-motion-apk.yml'
+  push:
+    branches: [main]
+    tags: ['motion-v*']
+
+permissions:
+  contents: write
+
+jobs:
+  verify:
+    name: Verify plugin contract
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      # Asserts the manifest still declares every key Projectivy reads, and
+      # that the vendored AIDL/parcelables still match Spocky's upstream API.
+      # A silent drift here is exactly what makes a plugin undetectable.
+      - name: Verify Projectivy plugin contract
+        run: python tools/verify_motion_plugin.py
+
+  apk:
+    name: Assemble plugin APK
+    needs: verify
+    runs-on: ubuntu-latest
+    env:
+      KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Refuse to build a tag that is not on main
+        if: startsWith(github.ref, 'refs/tags/motion-v')
+        run: |
+          git fetch origin main --depth=50
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main \
+            || { echo "::error::tag $GITHUB_REF_NAME is not an ancestor of main"; exit 1; }
+          TAG="${GITHUB_REF_NAME#motion-v}"
+          GRADLE=$(grep -oP 'versionName = "\K[^"]+' motion-plugin/app/build.gradle.kts)
+          [ "$TAG" = "$GRADLE" ] \
+            || { echo "::error::tag $TAG != versionName $GRADLE"; exit 1; }
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android platform 34
+        run: sdkmanager "platforms;android-34" "build-tools;34.0.0"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Decode keystore
+        if: env.KEYSTORE_BASE64 != ''
+        run: |
+          echo "$KEYSTORE_BASE64" | base64 -d > "$RUNNER_TEMP/release.jks"
+          echo "KEYSTORE_PATH=$RUNNER_TEMP/release.jks" >> "$GITHUB_ENV"
+          echo "Keystore decoded — release will be signed."
+
+      - name: Assemble release APK
+        if: startsWith(github.ref, 'refs/tags/motion-v')
+        working-directory: motion-plugin
+        env:
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        run: ./gradlew :app:assembleRelease --no-daemon --stacktrace
+
+      - name: Assemble debug APK
+        if: ${{ !startsWith(github.ref, 'refs/tags/motion-v') }}
+        working-directory: motion-plugin
+        run: ./gradlew :app:assembleDebug --no-daemon --stacktrace
+
+      # The single highest-value check in this workflow: prove the built APK
+      # really does expose the discovery intent + meta-data Projectivy needs.
+      # If aapt can't see it, no amount of on-device fiddling will help.
+      - name: Assert the built APK is discoverable by Projectivy
+        run: |
+          set -euo pipefail
+          if [ -d motion-plugin/app/build/outputs/apk/release ]; then
+            APK=$(ls motion-plugin/app/build/outputs/apk/release/*.apk | grep -v unsigned | head -1)
+          else
+            APK=$(ls motion-plugin/app/build/outputs/apk/debug/*.apk | head -1)
+          fi
+          echo "Inspecting $APK"
+          AAPT="$ANDROID_HOME/build-tools/34.0.0/aapt2"
+          DUMP=$("$AAPT" dump xmltree --file AndroidManifest.xml "$APK")
+
+          check() {
+            echo "$DUMP" | grep -q "$1" \
+              || { echo "::error::APK manifest is missing: $2"; exit 1; }
+            echo "  ok — $2"
+          }
+          check 'tv.projectivy.plugin.WALLPAPER_PROVIDER' 'discovery intent action'
+          check 'WallpaperProviderService'                'provider service'
+          check 'apiVersion'                              'apiVersion meta-data'
+          check 'uuid'                                    'uuid meta-data'
+          check 'settingsActivity'                        'settingsActivity meta-data'
+          check 'updateMode'                              'updateMode meta-data'
+
+          # A leanback hard requirement blocks install on Google TV / Fire TV
+          # variants that don't report the flag. Must be required=false.
+          if echo "$DUMP" | grep -A3 'android.software.leanback' | grep -q '0xffffffff'; then
+            echo "::error::android.software.leanback is required=true — this blocks install on some TV devices"
+            exit 1
+          fi
+          echo "APK is discoverable."
+
+      - name: Verify release APK is signed
+        if: startsWith(github.ref, 'refs/tags/motion-v')
+        run: |
+          APK=$(ls motion-plugin/app/build/outputs/apk/release/*.apk)
+          case "$APK" in
+            *-unsigned.apk)
+              echo "::error::$APK is unsigned — a tagged release must be installable."
+              exit 1
+              ;;
+          esac
+          "$ANDROID_HOME/build-tools/34.0.0/apksigner" verify --print-certs "$APK"
+
+      - name: Name the APK for the stable Downloader URL
+        if: startsWith(github.ref, 'refs/tags/motion-v')
+        run: |
+          SRC=$(ls motion-plugin/app/build/outputs/apk/release/*.apk | grep -v unsigned | head -1)
+          mkdir -p dist
+          cp "$SRC" dist/coremotion-release.apk
+          ls -lh dist/coremotion-release.apk
+
+      - name: Upload debug APK artifact
+        if: ${{ !startsWith(github.ref, 'refs/tags/motion-v') }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: CoreMotion-debug
+          path: motion-plugin/app/build/outputs/apk/debug/*.apk
+          if-no-files-found: error
+
+      - name: Upload release APK artifact
+        if: startsWith(github.ref, 'refs/tags/motion-v')
+        uses: actions/upload-artifact@v7
+        with:
+          name: CoreMotion-release
+          path: dist/coremotion-release.apk
+          if-no-files-found: error
+
+      - name: Publish versioned release
+        if: startsWith(github.ref, 'refs/tags/motion-v')
+        uses: softprops/action-gh-release@v3
+        with:
+          files: dist/coremotion-release.apk
+          generate_release_notes: true
+          name: "Core Motion ${{ github.ref_name }}"
+          make_latest: false
+
+      - name: Point floating tag motion at this commit
+        if: startsWith(github.ref, 'refs/tags/motion-v')
+        run: |
+          git tag -f motion "$GITHUB_SHA"
+          git push -f origin refs/tags/motion
+
+      - name: Publish stable Downloader release
+        if: startsWith(github.ref, 'refs/tags/motion-v')
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: motion
+          name: Core Motion (latest)
+          body: |
+            Always the current Core Motion APK — the Projectivy wallpaper-provider
+            plugin. Versioned notes live on `motion-v*` releases.
+
+            Install, then: Projectivy → Settings → Appearance → Wallpaper →
+            Launcher wallpaper → **Core Motion**. Requires Projectivy Premium.
+
+            Downloader (generate the numeric code **once** at https://go.aftvnews.com/):
+            https://github.com/brevityA/CoreBuildsApps/releases/download/motion/coremotion-release.apk
+          files: dist/coremotion-release.apk
+          fail_on_unmatched_files: true
+          make_latest: false

--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,11 @@
 /local.properties
 /.idea/
 .DS_Store
-/build
-/app/build
+# Unanchored on purpose: shift/ and motion-plugin/ are standalone Gradle roots,
+# so /build and /app/build alone left their outputs untracked-but-not-ignored.
+build/
+captures/
+.gradle/
 /captures
 .externalNativeBuild
 .cxx

--- a/Latestrelease/shift-version.json
+++ b/Latestrelease/shift-version.json
@@ -1,0 +1,8 @@
+{
+  "versionCode": 3,
+  "versionName": "2.0.1",
+  "releaseDate": "2026-08-23",
+  "apkUrl": "https://github.com/brevityA/CoreBuildsApps/releases/download/shift/coreshift-release.apk",
+  "releaseNotesUrl": "https://github.com/brevityA/CoreBuildsApps/releases",
+  "minSdk": 26
+}

--- a/Motion/aerial-entries.json
+++ b/Motion/aerial-entries.json
@@ -1,0 +1,74 @@
+{
+  "assets": [
+    {
+      "id": "coremotion_live_01_spiral_cyan",
+      "accessibilityLabel": "Spiral Cyan \u2014 Core Motion by Core Builds",
+      "type": "aerial",
+      "timeOfDay": "night",
+      "url-1080-SDR": "https://raw.githubusercontent.com/brevityA/CoreBuildsApps/main/Motion/live/coremotion-live-01-spiral-cyan.mp4"
+    },
+    {
+      "id": "coremotion_live_02_spiral_ember",
+      "accessibilityLabel": "Spiral Ember \u2014 Core Motion by Core Builds",
+      "type": "aerial",
+      "timeOfDay": "night",
+      "url-1080-SDR": "https://raw.githubusercontent.com/brevityA/CoreBuildsApps/main/Motion/live/coremotion-live-02-spiral-ember.mp4"
+    },
+    {
+      "id": "coremotion_live_03_radial_cyan",
+      "accessibilityLabel": "Radial Cyan \u2014 Core Motion by Core Builds",
+      "type": "aerial",
+      "timeOfDay": "night",
+      "url-1080-SDR": "https://raw.githubusercontent.com/brevityA/CoreBuildsApps/main/Motion/live/coremotion-live-03-radial-cyan.mp4"
+    },
+    {
+      "id": "coremotion_live_04_circular_void",
+      "accessibilityLabel": "Circular Void \u2014 Core Motion by Core Builds",
+      "type": "aerial",
+      "timeOfDay": "night",
+      "url-1080-SDR": "https://raw.githubusercontent.com/brevityA/CoreBuildsApps/main/Motion/live/coremotion-live-04-circular-void.mp4"
+    },
+    {
+      "id": "coremotion_live_05_circuit",
+      "accessibilityLabel": "Circuit \u2014 Core Motion by Core Builds",
+      "type": "aerial",
+      "timeOfDay": "night",
+      "url-1080-SDR": "https://raw.githubusercontent.com/brevityA/CoreBuildsApps/main/Motion/live/coremotion-live-05-circuit.mp4"
+    },
+    {
+      "id": "coremotion_live_06_deep_zoom",
+      "accessibilityLabel": "Deep Zoom \u2014 Core Motion by Core Builds",
+      "type": "aerial",
+      "timeOfDay": "night",
+      "url-1080-SDR": "https://raw.githubusercontent.com/brevityA/CoreBuildsApps/main/Motion/live/coremotion-live-06-deep-zoom.mp4"
+    },
+    {
+      "id": "coremotion_live_07_linear_blue",
+      "accessibilityLabel": "Linear Build Blue \u2014 Core Motion by Core Builds",
+      "type": "aerial",
+      "timeOfDay": "night",
+      "url-1080-SDR": "https://raw.githubusercontent.com/brevityA/CoreBuildsApps/main/Motion/live/coremotion-live-07-linear-blue.mp4"
+    },
+    {
+      "id": "coremotion_live_08_square_cyan",
+      "accessibilityLabel": "Square Cyan \u2014 Core Motion by Core Builds",
+      "type": "aerial",
+      "timeOfDay": "night",
+      "url-1080-SDR": "https://raw.githubusercontent.com/brevityA/CoreBuildsApps/main/Motion/live/coremotion-live-08-square-cyan.mp4"
+    },
+    {
+      "id": "coremotion_live_09_carpet",
+      "accessibilityLabel": "Carpet \u2014 Core Motion by Core Builds",
+      "type": "aerial",
+      "timeOfDay": "night",
+      "url-1080-SDR": "https://raw.githubusercontent.com/brevityA/CoreBuildsApps/main/Motion/live/coremotion-live-09-carpet.mp4"
+    },
+    {
+      "id": "coremotion_live_10_spiral_blue",
+      "accessibilityLabel": "Spiral Build Blue \u2014 Core Motion by Core Builds",
+      "type": "aerial",
+      "timeOfDay": "night",
+      "url-1080-SDR": "https://raw.githubusercontent.com/brevityA/CoreBuildsApps/main/Motion/live/coremotion-live-10-spiral-blue.mp4"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ Two delivery paths for motion wallpapers on Android TV:
 
 - **Monet Launcher** — browse live wallpapers in-app, full-screen looping preview, download MP4 loops to `Movies/CoreBuilds`. Point Monet Premium's video wallpaper picker at that folder.
 - **Projectivy Launcher** — the **Core Motion** plugin (`motion-plugin/`, `tv.corebuilds.motion`) implements Spocky's `IWallpaperProviderService` AIDL. Serves an Overflight-compatible JSON feed as `VIDEO` wallpapers plus bundled Lottie vector loops. Install [`coremotion-release.apk`](https://github.com/brevityA/CoreBuildsApps/releases/download/motion/coremotion-release.apk) → Projectivy Settings → Appearance → Wallpaper → Launcher wallpaper → Core Motion. Requires Projectivy Premium. Not detected? See [`docs/PROJECTIVY_DETECTION.md`](docs/PROJECTIVY_DETECTION.md).
+- **Monet Launcher** — no plugin API exists, so the route is the **Aerial Views bridge**: point Aerial Views at [`Motion/aerial-entries.json`](Motion/aerial-entries.json), then set Monet's wallpaper source to Aerial. Auto-updating, and gives you a matching screensaver. Local-file fallback via Core Shift → `Movies/CoreBuilds`. See [`docs/MONET_LAUNCHER.md`](docs/MONET_LAUNCHER.md).
 
 Content pipeline: 10 ffmpeg-filter MP4 loops (1080p H.264), 3 self-authored GLSL shaders (hex plasma, starfield, flowing noise), and bundled Lottie vectors — all §03 palette.
 

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Full architecture and remaining debt: [`ticker/HANDOVER.md`](ticker/HANDOVER.md)
 Two delivery paths for motion wallpapers on Android TV:
 
 - **Monet Launcher** — browse live wallpapers in-app, full-screen looping preview, download MP4 loops to `Movies/CoreBuilds`. Point Monet Premium's video wallpaper picker at that folder.
-- **Projectivy Launcher** — the **Core Motion** plugin (`motion-plugin/`, `tv.corebuilds.motion`) implements Spocky's `IWallpaperProviderService` AIDL. Serves an Overflight-compatible JSON feed as `VIDEO` wallpapers plus bundled Lottie vector loops. Sideload the plugin APK → Settings → Appearance → Wallpaper → Core Motion.
+- **Projectivy Launcher** — the **Core Motion** plugin (`motion-plugin/`, `tv.corebuilds.motion`) implements Spocky's `IWallpaperProviderService` AIDL. Serves an Overflight-compatible JSON feed as `VIDEO` wallpapers plus bundled Lottie vector loops. Install [`coremotion-release.apk`](https://github.com/brevityA/CoreBuildsApps/releases/download/motion/coremotion-release.apk) → Projectivy Settings → Appearance → Wallpaper → Launcher wallpaper → Core Motion. Requires Projectivy Premium. Not detected? See [`docs/PROJECTIVY_DETECTION.md`](docs/PROJECTIVY_DETECTION.md).
 
 Content pipeline: 10 ffmpeg-filter MP4 loops (1080p H.264), 3 self-authored GLSL shaders (hex plasma, starfield, flowing noise), and bundled Lottie vectors — all §03 palette.
 

--- a/docs/MONET_LAUNCHER.md
+++ b/docs/MONET_LAUNCHER.md
@@ -1,0 +1,151 @@
+# Core Motion on Monet Launcher
+
+How to get the Core Builds live wallpapers onto **Monet Launcher**
+(`com.klevico.monet`), and why it can't be done the same way as Projectivy.
+
+---
+
+## The short version
+
+**The Core Motion plugin cannot work with Monet, and no amount of work on our
+side will change that.** Monet has no wallpaper-provider plugin API. There is no
+intent action to answer, no AIDL to implement, no service to export. Projectivy
+is the outlier here — Spocky publishes a documented plugin contract; Klevico
+does not.
+
+Monet's wallpaper sources are a fixed list, baked into the closed-source APK:
+
+| Source | Third-party extensible? |
+|---|---|
+| Your own images | no — user picks files |
+| Your own videos | **yes, indirectly** — user picks files |
+| Built-in wallpapers | no |
+| Reddit | no — hardcoded subreddits |
+| **Aerial Views** | **yes** — Aerial Views itself takes custom feeds |
+| Cinematic movie posters | no |
+
+So there are exactly two routes, and one of them is good.
+
+---
+
+## Route A — the Aerial Views bridge (recommended)
+
+Monet added *"Aerial Views as a live wallpaper and screensaver, plus your own
+videos"* in v1.0.45. Aerial Views (`com.neilturner.aerialviews`, GPLv3) supports
+**custom remote feeds** in the "community" `entries.json` format.
+
+Chain the two and Monet gets our catalogue, auto-updating, without Klevico
+having to know we exist:
+
+```
+Motion/aerial-entries.json  ──▶  Aerial Views (custom feed)  ──▶  Monet Launcher
+        (we publish)                  (user pastes URL once)        (picks Aerial as source)
+```
+
+This is the closest thing to feature parity with the Projectivy plugin: one URL,
+set once, and new loops appear as we ship them. It also gets the user a matching
+*screensaver* for free, which the Projectivy plugin doesn't do.
+
+### The feed
+
+`tools/build_aerial_feed.py` projects `Motion/live-feed.json` (Overflight
+format, the source of truth) into Aerial Views' format. Never hand-edit the
+output; CI checks the two stay in sync.
+
+```
+https://raw.githubusercontent.com/brevityA/CoreBuildsApps/main/Motion/aerial-entries.json
+```
+
+Format mapping:
+
+| Overflight (`live-feed.json`) | Aerial Views (`aerial-entries.json`) |
+|---|---|
+| `url_1080p` | `url-1080-SDR` |
+| `url_4k` | `url-4K-SDR` |
+| `title` + `location` + `author` | `accessibilityLabel` (only place attribution surfaces) |
+| filename stem | `id` — stable, so favourites survive a retitle |
+| — | `type: "aerial"` |
+| — | `timeOfDay: "night"` |
+
+`timeOfDay` matters: the Core Builds palette is dark-first (Night `#0D1117`,
+Void `#04070F`). Tagging these `day` makes Aerial Views skip them for anyone
+using time-of-day filtering, which reads to the user as a broken feed.
+
+### User steps
+
+1. Install **Aerial Views** (Play Store, Amazon Appstore, or GitHub APK).
+2. Aerial Views → `Settings → Custom feeds` (or `Custom Media URLs`) → add:
+   `https://raw.githubusercontent.com/brevityA/CoreBuildsApps/main/Motion/aerial-entries.json`
+3. Optionally disable the Apple/Amazon/Jetson sources so only Core Motion plays.
+4. Monet → `Settings → Wallpaper → Source → Aerial`.
+5. Monet extracts its Material You palette from the video frames — Core Cyan
+   `#00E5FF` carries into the tiles and accents.
+
+Same feed also works in Projectivy via Overflight, and Aerial Views is *itself*
+a Projectivy wallpaper provider, so this one file covers three launchers.
+
+---
+
+## Route B — local files (already works today)
+
+Monet plays videos from local storage. Core Shift already downloads loops to
+`Movies/CoreBuilds`, which is exactly the right shape for this:
+
+1. Core Shift → pick a loop → **Download**.
+2. Monet → `Settings → Wallpaper → Your own videos` → browse to
+   `Movies/CoreBuilds` → pick the `.mp4`.
+
+Offline and reliable, but manual, one-at-a-time, and doesn't auto-update. Worth
+keeping as the fallback for anyone who won't install a second app — and it's the
+only route on Fire TV if Aerial Views' storage permissions get awkward.
+
+**Improvement worth making:** Core Shift's success message currently says
+*"Saved to Movies/CoreBuilds — set it in Monet"*, which leaves the user to find
+the folder themselves. Firing an `ACTION_VIEW` on the saved file, or at minimum
+naming the exact path in the toast, would close that gap. Low effort, real payoff.
+
+---
+
+## Route C — ask Klevico for a provider API (long game)
+
+Worth opening as a feature request on `Klevico/Monet-Launcher`, because Monet
+already has the two pieces that make it cheap:
+
+- it consumes remote video lists (the Aerial integration proves the plumbing);
+- it already supports third-party **icon packs**, so it has a precedent for
+  reading from other installed apps.
+
+The concrete ask is small: let a user paste an arbitrary
+`entries.json`/Overflight URL directly into Monet's wallpaper settings, skipping
+Aerial Views. That's a text field and an HTTP fetch, and it would serve every
+wallpaper project on Android TV, not just ours.
+
+A full Projectivy-style AIDL plugin API is the bigger ask and much less likely
+to land.
+
+---
+
+## What we are NOT going to do
+
+- **Ship a Monet "plugin".** There is no plugin surface. Anything claiming to be
+  one would be a lie.
+- **Set the system wallpaper via `WallpaperManager`.** Monet themes from *its
+  own* wallpaper setting, not the system one, so this changes nothing on the
+  home screen. (It also fails outright on Fire TV, which blocks third-party
+  wallpaper writes — the icon pack already works around this by saving to
+  `Pictures/CoreBuilds`.)
+- **Reverse-engineer Monet's preference store** to inject a wallpaper path.
+  It's closed source, unsigned-writable only via root, and would break on every
+  update.
+
+---
+
+## Summary
+
+| Launcher | Route | Auto-updating | Status |
+|---|---|---|---|
+| Projectivy | Core Motion plugin (AIDL) | yes | shipping — see `docs/PROJECTIVY_DETECTION.md` |
+| Projectivy | Overflight + our feed URL | yes | works today, no install needed |
+| Monet | Aerial Views + `aerial-entries.json` | yes | **feed shipping now** |
+| Monet | Core Shift → `Movies/CoreBuilds` | no | works today |
+| Any | Aerial Views as screensaver | yes | free side-effect of Route A |

--- a/docs/PROJECTIVY_DETECTION.md
+++ b/docs/PROJECTIVY_DETECTION.md
@@ -1,0 +1,233 @@
+# Core Motion — why Projectivy doesn't detect it
+
+Deep-dive root-cause analysis, verified against Spocky's official template
+(`spocky/projectivy-plugin-wallpaper-provider`, `main`) and the state of this
+repo at `1d5c692` (Core Shift v2.0.1).
+
+---
+
+## TL;DR
+
+**The plugin is not detected because the plugin is not installed — because it is
+never built.** Nothing in CI compiles `motion-plugin/`, and no GitHub Release in
+this repo has ever contained a Core Motion APK. Every release asset to date is
+`coreshift-release.apk`, `coreline-release.apk`, or `iconpack-release.apk`.
+
+Everything downstream of that (manifest keys, AIDL, UUID) is actually **correct**
+— I diffed it byte-for-byte against the upstream template and it matches. So the
+fix is a release pipeline, not a code rewrite. The secondary findings below are
+real but would only bite *after* you get an APK onto the device.
+
+---
+
+## Verification: how Projectivy actually discovers a provider
+
+Projectivy enumerates installed packages with
+
+```
+PackageManager.queryIntentServices(Intent("tv.projectivy.plugin.WALLPAPER_PROVIDER"), GET_META_DATA)
+```
+
+and for each hit reads the **service-level** `<meta-data>`: `apiVersion`, `uuid`,
+`name`, `settingsActivity`, `itemsCacheDurationMillis`, `updateMode`. It then
+binds to the service and calls `IWallpaperProviderService.getWallpapers(Event)`.
+
+For a plugin to appear in *Settings → Appearance → Wallpaper → Launcher
+wallpaper*, **all** of these must hold:
+
+| # | Requirement | Core Motion status |
+|---|---|---|
+| 1 | The APK is installed on the device | ❌ **never built or published** |
+| 2 | Exported service with `<action tv.projectivy.plugin.WALLPAPER_PROVIDER/>` | ✅ correct |
+| 3 | `apiVersion` meta-data = `1` | ✅ correct |
+| 4 | `uuid` meta-data, valid UUID v4, not `CHANGE_ME` | ✅ `295b637c-aa92-4d09-8f54-74c4806e1e80` |
+| 5 | `name` meta-data | ✅ `Core Motion` |
+| 6 | AIDL interface descriptor byte-identical to upstream | ✅ verified by diff |
+| 7 | `Wallpaper` / `Event` parcelables byte-identical to upstream | ✅ verified by diff |
+| 8 | Projectivy **Premium** is active | ⚠️ user-side, must confirm |
+| 9 | App is installed for the *current* Android user/profile | ⚠️ user-side |
+| 10 | Service class survives R8 | ✅ `isMinifyEnabled = false` |
+
+---
+
+## Finding 1 — CRITICAL: no build, no artifact, no release
+
+`motion-plugin/` is a standalone Gradle root (`motion-plugin/settings.gradle.kts`,
+`rootProject.name = "CoreMotionPlugin"`). It is referenced by **zero** workflows:
+
+```
+$ grep -rn "motion-plugin" .github/workflows/
+(no matches)
+```
+
+`.github/workflows/` contains `build.yml` (icon pack), `core-line-apk.yml`,
+`core-shift-apk.yml`, `device-check.yml`. `core-shift-apk.yml` builds
+`shift/` only — its `working-directory: shift` and its path filters
+(`shift/**`, `Motion/**`, `tools/validate_motion.py`) never touch the plugin.
+
+Release assets, via the API:
+
+```
+shift-v2.0.1  → coreshift-release.apk
+shift         → coreshift-release.apk
+v1.7.1        → app-release.apk, iconpack-release.apk
+coreline      → coreline-release.apk
+…             (no coremotion-*.apk anywhere)
+```
+
+Meanwhile `README.md:239` and `motion-plugin/README.md` both tell the user to
+"sideload the plugin APK" — an APK that has never existed. And Core Shift
+`strings.xml` says *"Projectivy users: install the Core Motion plugin."*
+
+Worth stating plainly, because it's the most common misunderstanding here:
+**Core Shift is not a Projectivy plugin and can never be detected as one.**
+`shift/app/src/main/AndroidManifest.xml` declares two activities and no service
+at all. Installing Core Shift and then looking in Projectivy's wallpaper-source
+list will always come up empty. They are two separate APKs with two separate
+package names (`dev.corebuilds.shift` vs `tv.corebuilds.motion`).
+
+**Fix:** `.github/workflows/core-motion-apk.yml` (added) — builds, signs and
+publishes `coremotion-release.apk` on `motion-v*` tags, and force-moves a
+floating `motion` tag so there is a stable Downloader URL, exactly mirroring the
+`shift` pattern.
+
+---
+
+## Finding 2 — HIGH: `android.software.leanback` is `required="true"`
+
+```xml
+<uses-feature android:name="android.software.leanback" android:required="true" />
+```
+
+Inherited from the upstream template. It hard-gates *installation* on the
+feature flag. In practice this bites on:
+
+- **Google TV / Chromecast with Google TV** builds that report
+  `android.software.leanback` inconsistently across OS updates;
+- **Fire TV** — Fire OS is Leanback-ish, but the flag has moved between Fire OS
+  releases, and `adb install` will reject with `INSTALL_FAILED_MISSING_SHARED_LIBRARY`
+  / `INSTALL_FAILED_MISSING_FEATURE` rather than anything obvious;
+- **projector/AOSP TV boxes** running plain AOSP with Projectivy on top;
+- any attempt to test on an emulator or handset.
+
+The failure mode is indistinguishable from "Projectivy doesn't see it", because
+the user sees an install that silently fails or a package that isn't there.
+Projectivy itself does not require your plugin to declare leanback.
+
+**Fix:** `required="false"`. Keeps TV-store categorisation via
+`LEANBACK_LAUNCHER`, removes the install gate.
+
+---
+
+## Finding 3 — HIGH: 20 s blocking network call on the binder thread
+
+`MotionFeed.TIMEOUT_MS = 20_000`, and `WallpaperProviderService.getWallpapers()`
+calls `MotionFeed.load()` synchronously with **both** `connectTimeout` and
+`readTimeout` at 20 s — a worst case of ~40 s inside a single binder
+transaction.
+
+`getWallpapers()` is not on Projectivy's main thread, but Projectivy's binding
+code has its own patience. A provider that blocks for tens of seconds looks
+broken: Projectivy falls back to its cached/default wallpaper, and on some
+Android TV builds the binder transaction itself is reaped. Users read that as
+"the plugin doesn't work / isn't detected". Spocky's own guidance in the
+template README is explicit — *"be responsible: even though getWallpapers()
+isn't called from the UI thread, it doesn't mean you can waste precious device
+resources"*.
+
+Compounding it: the plugin returns **two bundled Lottie wallpapers first**, then
+appends the feed. If the fetch throws, you still return 2 items, so the plugin
+*appears* selectable but only ever cycles two vectors — an easy misdiagnosis.
+
+**Fix:** 6 s connect / 8 s read, plus an in-memory feed cache keyed on URL with a
+TTL, so repeat `getWallpapers()` calls inside `itemsCacheDurationMillis` never
+hit the network at all.
+
+---
+
+## Finding 4 — MEDIUM: no way to see what Projectivy sees
+
+There is no diagnostic anywhere. When it doesn't work you have no signal.
+
+**Fix:** the settings screen (`SettingsFragment`) now renders a live
+self-check — is Projectivy installed, does `queryIntentServices` resolve *this
+plugin's own service*, and are `apiVersion` / `uuid` / `name` readable from the
+resolved `ServiceInfo.metaData`. That is precisely the query Projectivy runs, so
+if that panel is green and Projectivy still shows nothing, the problem is
+Premium or the launcher's cache — not the plugin.
+
+Also added `tools/verify_motion_plugin.py`: a static check that the manifest
+declares every required key and that the vendored AIDL + parcelables still match
+upstream. Wired into the new workflow so a future refactor can't silently break
+discovery.
+
+---
+
+## Finding 5 — LOW / user-side, but check these first
+
+- **Premium.** Third-party wallpaper providers are a Projectivy **Premium**
+  feature. Without it the plugin section does not render at all. Overflight's
+  own store listing says the same. Confirm via *Settings → About → Get premium*.
+- **Projectivy caches the plugin list.** Historically it refreshes on package
+  add/remove, but the launcher is long-lived and users report stale lists.
+  After sideloading: `adb shell am force-stop com.spocky.projengmenu`, or
+  Settings → Apps → Projectivy → Force stop, then reopen.
+- **Wrong Android user.** Sideloading via a file manager running in a secondary
+  profile installs into that profile; Projectivy in the primary profile can't
+  see it. `adb install -r --user 0`.
+- **Signature.** Sideloaded debug-signed builds are fine; Projectivy does no
+  signature check. But if you install a debug build over a release build (or
+  vice-versa) the install fails with `INSTALL_FAILED_UPDATE_INCOMPATIBLE` and
+  leaves nothing installed.
+
+---
+
+## Reproduce / verify on-device
+
+```bash
+# 1. Is it installed at all, in user 0?
+adb shell pm list packages --user 0 | grep tv.corebuilds.motion
+
+# 2. Does the system resolve the discovery intent? This is Projectivy's query.
+adb shell dumpsys package tv.corebuilds.motion | sed -n '/WallpaperProviderService/,/^$/p'
+adb shell cmd package query-services -a tv.projectivy.plugin.WALLPAPER_PROVIDER
+
+# 3. Are the meta-data keys present on the *service*?
+adb shell dumpsys package tv.corebuilds.motion | grep -A2 -E 'apiVersion|uuid|settingsActivity'
+
+# 4. Watch the plugin get bound and serve wallpapers
+adb logcat -c && adb logcat | grep -iE 'CoreMotion|projengmenu|WallpaperProvider'
+
+# 5. Force Projectivy to re-enumerate
+adb shell am force-stop com.spocky.projengmenu
+```
+
+Expected from step 2: one service, `tv.corebuilds.motion/.WallpaperProviderService`.
+If that prints nothing, the APK isn't installed (Finding 1/2). If it prints the
+service and Projectivy still shows no source, it's Premium or the launcher cache
+(Finding 5).
+
+---
+
+## What was checked and found correct
+
+Recorded so nobody re-litigates it:
+
+- `motion-plugin/.../aidl/tv/projectivy/plugin/wallpaperprovider/api/*.aidl` —
+  identical to upstream (`diff` clean, all three files).
+- `.../java/tv/projectivy/plugin/wallpaperprovider/api/{Event,Wallpaper,WallpaperProviderContract}.kt`
+  — identical to upstream (`diff` clean).
+- Package of the API classes is `tv.projectivy.plugin.wallpaperprovider.api`,
+  **not** relocated under `tv.corebuilds.*`. Relocating it is the classic way to
+  break discovery; this repo did it right.
+- `buildFeatures { aidl = true }` is set (mandatory from AGP 8).
+- `kotlin-parcelize` plugin applied — required for `@Parcelize` on `Wallpaper`.
+- `isMinifyEnabled = false`, so R8 cannot strip `WallpaperProviderService` or the
+  generated `Stub`. (If you ever turn minify on, you need
+  `-keep class tv.projectivy.plugin.wallpaperprovider.api.** { *; }` and
+  `-keep class tv.corebuilds.motion.WallpaperProviderService { *; }`.)
+- The service is `android:exported="true"` with the correct action, and the
+  meta-data sits on the `<service>` (not the `<application>`), which is where
+  Projectivy reads it.
+- `applicationId` does **not** need to live under `tv.projectivy.*`; third-party
+  plugins in the wild use their own namespaces.

--- a/docs/shift-list-motion-preview.html
+++ b/docs/shift-list-motion-preview.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Core Shift — list motion preview</title>
+<style>
+  :root{
+    --night:#0D1117; --void:#04070F; --surface:#161B22; --surface-focus:#1B2634;
+    --cyan:#00E5FF; --signal:#00D4FF; --glow:#7EEEFF; --blue:#4FACFE;
+    --violet:#8A4890; --ember:#C03A20;
+    --text:#E6EDF3; --text-dim:#8B949E;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  body{
+    background:var(--night); color:var(--text);
+    font-family:'Segoe UI',system-ui,-apple-system,sans-serif;
+    padding:32px 40px 48px; min-height:100vh;
+  }
+  h1{font-size:28px;font-weight:700;color:var(--cyan);letter-spacing:.2px}
+  /* Spectrum rule — the wallpaper suite ramp, travelling. */
+  .rule{
+    width:220px;height:3px;margin-top:8px;border-radius:2px;
+    background:linear-gradient(90deg,var(--cyan),var(--glow),var(--blue),var(--violet),var(--ember),var(--cyan));
+    background-size:300% 100%;
+    animation:sweep 11s linear infinite;
+  }
+  @keyframes sweep{from{background-position:0% 0}to{background-position:300% 0}}
+  .hint{margin-top:12px;color:var(--text-dim);font-size:14px;max-width:760px;line-height:1.5}
+  .keys{margin-top:6px;color:var(--blue);font-size:13px;font-family:ui-monospace,monospace}
+
+  .list{margin-top:22px;display:flex;flex-direction:column;gap:0;perspective:1000px}
+
+  .row{padding:4px 0 8px;}
+  .card{
+    display:flex;align-items:center;gap:0;
+    background:var(--surface);
+    border:2px solid transparent;border-radius:12px;
+    padding:12px 12px 12px 0;
+    transform-origin:left center;
+    transition:transform .22s cubic-bezier(.2,.7,.3,1),
+               background-color .22s ease,
+               border-color .22s ease;
+    /* staggered entry */
+    opacity:0; animation:rise .3s cubic-bezier(.15,.8,.3,1) forwards;
+  }
+  @keyframes rise{
+    from{opacity:0;transform:translateY(14px) scale(.97)}
+    to  {opacity:1;transform:translateY(0) scale(1)}
+  }
+
+  .spine{
+    width:4px;align-self:stretch;margin:8px 8px 8px 4px;border-radius:2px;
+    background:linear-gradient(180deg,var(--cyan),var(--blue),var(--violet));
+    background-size:100% 250%;
+    opacity:0;transform:scaleY(.2);transform-origin:top;
+    transition:opacity .22s ease,transform .22s cubic-bezier(.2,.7,.3,1);
+  }
+
+  .thumbwrap{width:128px;height:72px;overflow:hidden;flex:0 0 auto;border-radius:3px}
+  .thumb{
+    width:100%;height:100%;
+    filter:saturate(.45);opacity:.8;
+    transition:filter .22s ease,opacity .22s ease,transform .22s ease;
+  }
+  .meta{flex:1;margin-left:16px;min-width:0}
+  .title{font-size:18px}
+  .spec,.status{font-family:ui-monospace,monospace;font-size:13px}
+  .spec{color:var(--text-dim);margin-top:2px}
+  .status{color:var(--cyan);margin-top:2px;min-height:17px}
+
+  .btns{display:flex;flex-direction:column;gap:6px}
+  .btn{
+    min-width:120px;padding:8px 14px;border-radius:6px;font-size:15px;
+    background:#1B2634;border:1px solid var(--text-dim);color:var(--text);
+    text-align:center;transition:all .15s ease;
+  }
+
+  /* ---- focused state ---- */
+  .row.on .card{
+    transform:scale(1.03);
+    background:var(--surface-focus);
+    box-shadow:0 10px 28px rgba(0,0,0,.55);
+    animation:rise .3s cubic-bezier(.15,.8,.3,1) forwards, border-sweep 7s linear infinite .3s;
+  }
+  @keyframes border-sweep{
+    0%  {border-color:var(--cyan)}
+    25% {border-color:var(--glow)}
+    50% {border-color:var(--blue)}
+    75% {border-color:var(--violet)}
+    100%{border-color:var(--cyan)}
+  }
+  .row.on .spine{opacity:1;transform:scaleY(1);animation:spine-sweep 7s linear infinite}
+  @keyframes spine-sweep{from{background-position:0 0}to{background-position:0 250%}}
+
+  .row.on .thumb{
+    filter:saturate(1);opacity:1;
+    animation:kenburns 6s ease-in-out infinite alternate;
+  }
+  @keyframes kenburns{from{transform:scale(1)}to{transform:scale(1.07)}}
+
+  .row.on .btn.sel{background:var(--cyan);color:#04070F;border-color:var(--cyan);font-weight:600}
+
+  .note{margin-top:34px;padding-top:18px;border-top:1px solid #1B2634;
+        color:var(--text-dim);font-size:13px;line-height:1.6;max-width:820px}
+  .note b{color:var(--text)}
+  code{color:var(--glow);font-family:ui-monospace,monospace}
+</style>
+</head>
+<body>
+  <h1>Core Shift</h1>
+  <div class="rule"></div>
+  <p class="hint">Core Builds live wallpapers. Preview in-app, or download to Movies/CoreBuilds for Monet. Projectivy users: install the Core Motion plugin.</p>
+  <p class="keys">↑ ↓ move focus &nbsp;·&nbsp; ← → switch button &nbsp;·&nbsp; this is a faithful mock of the Android focus motion, not the app</p>
+
+  <div class="list" id="list"></div>
+
+  <div class="note">
+    <b>What you're looking at.</b> Each row's focus state runs four things off one state change:
+    the card lifts (scale&nbsp;1.03 + elevation), the border travels the wallpaper suite's
+    <code>cyan → glow → build&nbsp;blue → dusk&nbsp;violet</code> ramp, the leading spine wipes in from
+    the top on the same phase, and the poster saturates from 45% to full while slowly drifting.
+    Resting rows stay desaturated — with ten cyan-heavy thumbs stacked up, that contrast is what
+    creates the depth. Entry is a 12%-staggered rise so the whole list settles in about 700&nbsp;ms.
+    The header rule is the only always-on animation; everything else is focus-driven, which keeps
+    idle CPU near zero on weak TV SoCs.
+  </div>
+
+<script>
+const items = [
+  ["Spiral Cyan","1080p · 20s loop","linear-gradient(135deg,#04070F 0%,#00E5FF 55%,#4FACFE 100%)"],
+  ["Spiral Ember","1080p · 20s loop","linear-gradient(135deg,#04070F 0%,#C03A20 55%,#8A4890 100%)"],
+  ["Radial Cyan","1080p · 20s loop","radial-gradient(circle at 35% 45%,#7EEEFF 0%,#00A0C0 35%,#04070F 75%)"],
+  ["Circular Void","1080p · 20s loop","radial-gradient(circle at 60% 50%,#4FACFE 0%,#0D1117 60%)"],
+  ["Circuit","1080p · 20s loop","linear-gradient(90deg,#04070F 0%,#00E5FF 30%,#04070F 60%,#4FACFE 100%)"],
+  ["Deep Zoom","4K · 20s loop","radial-gradient(circle at 50% 50%,#8A4890 0%,#00E5FF 40%,#04070F 85%)"],
+  ["Linear Blue","1080p · 20s loop","linear-gradient(160deg,#0D1117 0%,#4FACFE 70%,#7EEEFF 100%)"],
+  ["Square Cyan","1080p · 20s loop","conic-gradient(from 45deg,#00E5FF,#04070F,#4FACFE,#04070F,#00E5FF)"],
+];
+
+const list = document.getElementById('list');
+items.forEach((it,i)=>{
+  const row = document.createElement('div');
+  row.className = 'row';
+  row.innerHTML = `
+    <div class="card" style="animation-delay:${i*38}ms">
+      <div class="spine"></div>
+      <div class="thumbwrap"><div class="thumb" style="background:${it[2]}"></div></div>
+      <div class="meta">
+        <div class="title">${it[0]}</div>
+        <div class="spec">${it[1]}</div>
+        <div class="status"></div>
+      </div>
+      <div class="btns">
+        <div class="btn b0">Preview</div>
+        <div class="btn b1">Download</div>
+      </div>
+    </div>`;
+  list.appendChild(row);
+});
+
+let idx = 0, btn = 0;
+const rows = [...document.querySelectorAll('.row')];
+function paint(){
+  rows.forEach((r,i)=>{
+    r.classList.toggle('on', i===idx);
+    r.querySelector('.b0').classList.toggle('sel', i===idx && btn===0);
+    r.querySelector('.b1').classList.toggle('sel', i===idx && btn===1);
+  });
+  rows[idx].scrollIntoView({block:'nearest',behavior:'smooth'});
+}
+addEventListener('keydown',e=>{
+  if(e.key==='ArrowDown'){idx=Math.min(idx+1,rows.length-1);e.preventDefault()}
+  else if(e.key==='ArrowUp'){idx=Math.max(idx-1,0);e.preventDefault()}
+  else if(e.key==='ArrowRight'){btn=1;e.preventDefault()}
+  else if(e.key==='ArrowLeft'){btn=0;e.preventDefault()}
+  else return;
+  paint();
+});
+rows.forEach((r,i)=>r.addEventListener('mouseenter',()=>{idx=i;paint()}));
+setTimeout(paint, 400);
+</script>
+</body>
+</html>

--- a/motion-plugin/README.md
+++ b/motion-plugin/README.md
@@ -87,3 +87,9 @@ AGP 8.5.2 / Kotlin 1.9.24 / compileSdk 34 / minSdk 26).
 
 `url_1080p`/`url_4k` → VIDEO wallpaper; `url_img` alone → IMAGE wallpaper.
 Regenerate the procedural set with `python tools/build_motion_feed.py`.
+
+## Other launchers
+
+Monet Launcher has no wallpaper-provider plugin API — this plugin cannot work
+there. The supported route is the Aerial Views bridge
+(`Motion/aerial-entries.json`); see [`docs/MONET_LAUNCHER.md`](../docs/MONET_LAUNCHER.md).

--- a/motion-plugin/README.md
+++ b/motion-plugin/README.md
@@ -20,12 +20,38 @@ Projectivy via the `tv.projectivy.plugin.WALLPAPER_PROVIDER` intent action.
 
 ## Install & use
 
-1. Build the APK (`./gradlew :app:assembleDebug`), sideload it.
-2. Projectivy → **Settings → Appearance → Wallpaper** → choose **Core Motion**.
+Grab the prebuilt APK — CI publishes one on every `motion-v*` tag, and the
+floating `motion` tag is always the current build:
+
+```
+https://github.com/brevityA/CoreBuildsApps/releases/download/motion/coremotion-release.apk
+```
+
+Or build it yourself: `cd motion-plugin && ./gradlew :app:assembleDebug`.
+
+1. Sideload the APK (Downloader, or `adb install -r --user 0 coremotion-release.apk`).
+2. Projectivy → **Settings → Appearance → Wallpaper → Launcher wallpaper** →
+   choose **Core Motion**.
 3. (Optional) open Core Motion's settings to change the feed URL.
 
 > Requires **Projectivy Launcher Premium** — the same as Overflight and every
 > wallpaper provider, because custom wallpaper providers are a Premium feature.
+
+Core Motion has no launcher icon of its own on some setups; it is configured
+from inside Projectivy, or from *Android Settings → Apps → Core Motion*.
+
+## If Projectivy doesn't list it
+
+Open the plugin's settings screen — it runs the **same `queryIntentServices`
+query Projectivy runs** and reports what it found, line by line. If every line
+is green, the plugin is discoverable and the problem is on the launcher side
+(Premium inactive, or a stale plugin list that a force-stop clears).
+
+Full root-cause guide, including `adb` commands:
+[`docs/PROJECTIVY_DETECTION.md`](../docs/PROJECTIVY_DETECTION.md).
+
+`python tools/verify_motion_plugin.py` checks the manifest contract and the
+vendored-API parity offline; CI runs it on every change to this directory.
 
 ## The contract (do not change)
 

--- a/motion-plugin/app/build.gradle.kts
+++ b/motion-plugin/app/build.gradle.kts
@@ -13,7 +13,7 @@ android {
         minSdk = 26
         targetSdk = 34
         versionCode = 1
-        versionName = "0.1.0"
+        versionName = "1.0.0"
     }
 
     signingConfigs {

--- a/motion-plugin/app/src/main/AndroidManifest.xml
+++ b/motion-plugin/app/src/main/AndroidManifest.xml
@@ -9,12 +9,22 @@
     <uses-feature
         android:name="android.hardware.touchscreen"
         android:required="false" />
+    <!-- required=false on purpose. A hard leanback requirement blocks install on
+         Google TV / Fire TV builds that don't report the flag, and a failed
+         install is indistinguishable from "Projectivy can't see the plugin".
+         Projectivy does not require plugins to declare leanback. -->
     <uses-feature
         android:name="android.software.leanback"
-        android:required="true" />
+        android:required="false" />
 
     <queries>
         <package android:name="com.spocky.projengmenu" />
+        <!-- Lets the built-in diagnostic enumerate other installed wallpaper
+             providers as a control: if Overflight resolves here and Core Motion
+             doesn't, the fault is definitively in this APK. -->
+        <intent>
+            <action android:name="tv.projectivy.plugin.WALLPAPER_PROVIDER" />
+        </intent>
     </queries>
 
     <application
@@ -39,6 +49,8 @@
         <service
             android:name=".WallpaperProviderService"
             android:exported="true"
+            android:enabled="true"
+            android:directBootAware="false"
             android:label="@string/plugin_name"
             android:icon="@mipmap/ic_launcher"
             android:banner="@drawable/ic_plugin"

--- a/motion-plugin/app/src/main/java/tv/corebuilds/motion/Diagnostics.kt
+++ b/motion-plugin/app/src/main/java/tv/corebuilds/motion/Diagnostics.kt
@@ -1,0 +1,119 @@
+package tv.corebuilds.motion
+
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.content.pm.ResolveInfo
+
+/**
+ * Runs, on-device, exactly the query Projectivy runs to discover wallpaper
+ * providers — then reports what it found.
+ *
+ * The point is to collapse the ambiguity in "Projectivy doesn't see the plugin".
+ * If this reports every line green and the launcher still shows no source, the
+ * problem is on Projectivy's side (Premium not active, or a stale plugin list
+ * that a force-stop clears) and not in this APK.
+ *
+ * See docs/PROJECTIVY_DETECTION.md.
+ */
+object Diagnostics {
+
+    const val PROJECTIVY_PACKAGE_ID = "com.spocky.projengmenu"
+    private const val DISCOVERY_ACTION = "tv.projectivy.plugin.WALLPAPER_PROVIDER"
+
+    data class Check(val label: String, val passed: Boolean, val detail: String)
+
+    data class Report(val checks: List<Check>) {
+        val allPassed: Boolean get() = checks.all { it.passed }
+
+        /** Compact multi-line summary for the settings screen. */
+        fun render(): String = buildString {
+            for (c in checks) {
+                append(if (c.passed) "✓ " else "✗ ")
+                append(c.label)
+                if (c.detail.isNotBlank()) {
+                    append(" — ")
+                    append(c.detail)
+                }
+                append('\n')
+            }
+            append('\n')
+            append(
+                if (allPassed) {
+                    "This plugin is discoverable. If Projectivy still shows no " +
+                        "\"Core Motion\" source, check that Premium is active, then " +
+                        "force-stop Projectivy so it re-reads the plugin list."
+                } else {
+                    "Something above is blocking discovery. Reinstall the plugin " +
+                        "APK for this user profile, then reopen this screen."
+                },
+            )
+        }
+    }
+
+    fun run(context: Context): Report {
+        val pm = context.packageManager
+        val checks = mutableListOf<Check>()
+
+        // 1 — is the launcher even here?
+        val projectivy = runCatching { pm.getPackageInfo(PROJECTIVY_PACKAGE_ID, 0) }.getOrNull()
+        checks += Check(
+            "Projectivy installed",
+            projectivy != null,
+            projectivy?.let { "v${it.versionName}" } ?: "not found",
+        )
+
+        // 2 — the discovery query itself, GET_META_DATA, same as Projectivy.
+        val resolved: List<ResolveInfo> = runCatching {
+            pm.queryIntentServices(Intent(DISCOVERY_ACTION), PackageManager.GET_META_DATA)
+        }.getOrDefault(emptyList())
+
+        val mine = resolved.firstOrNull {
+            it.serviceInfo?.packageName == context.packageName
+        }
+        checks += Check(
+            "Own service resolves",
+            mine != null,
+            if (mine != null) {
+                mine.serviceInfo.name.substringAfterLast('.')
+            } else {
+                "the WALLPAPER_PROVIDER intent does not resolve to this app"
+            },
+        )
+
+        // 3 — the meta-data Projectivy reads off that service.
+        val meta = mine?.serviceInfo?.metaData
+        val apiVersion = meta?.get("apiVersion")?.toString()
+        checks += Check("apiVersion", apiVersion == "1", apiVersion ?: "missing")
+
+        val uuid = meta?.get("uuid")?.toString()
+        checks += Check(
+            "Plugin UUID",
+            !uuid.isNullOrBlank() && uuid != "CHANGE_ME",
+            uuid?.take(8)?.plus("…") ?: "missing",
+        )
+
+        val name = meta?.get("name")?.toString()
+        checks += Check("Plugin name", !name.isNullOrBlank(), name ?: "missing")
+
+        val settingsActivity = meta?.get("settingsActivity")?.toString()
+        checks += Check(
+            "Settings activity",
+            !settingsActivity.isNullOrBlank(),
+            settingsActivity ?: "missing",
+        )
+
+        // 4 — other providers found, useful as a control. If Overflight shows up
+        //     here and Core Motion doesn't, the fault is definitively ours.
+        val others = resolved
+            .mapNotNull { it.serviceInfo?.packageName }
+            .filter { it != context.packageName }
+        checks += Check(
+            "Other providers seen",
+            true,
+            if (others.isEmpty()) "none" else others.joinToString { it.substringAfterLast('.') },
+        )
+
+        return Report(checks)
+    }
+}

--- a/motion-plugin/app/src/main/java/tv/corebuilds/motion/MotionFeed.kt
+++ b/motion-plugin/app/src/main/java/tv/corebuilds/motion/MotionFeed.kt
@@ -18,7 +18,22 @@ import java.net.URL
 object MotionFeed {
 
     private const val TAG = "CoreMotion"
-    private const val TIMEOUT_MS = 20_000
+
+    /** Projectivy calls getWallpapers() on a binder thread and waits. Spocky's
+     *  own guidance is to be frugal here, so keep the worst case well under
+     *  ~15s rather than the 40s a 20s connect + 20s read allows. A provider
+     *  that stalls looks broken and Projectivy falls back to its cache. */
+    private const val CONNECT_TIMEOUT_MS = 6_000
+    private const val READ_TIMEOUT_MS = 8_000
+
+    /** In-memory feed cache. Projectivy already caches results for
+     *  itemsCacheDurationMillis, but it re-binds the service freely and other
+     *  events can trigger extra calls; this makes those free. */
+    private const val CACHE_TTL_MS = 15 * 60 * 1000L
+
+    private var cachedUrl: String? = null
+    private var cachedAt: Long = 0L
+    private var cachedWallpapers: List<Wallpaper> = emptyList()
 
     const val DEFAULT_FEED_URL =
         "https://raw.githubusercontent.com/brevityA/CoreBuildsApps/main/Motion/live-feed.json"
@@ -30,9 +45,20 @@ object MotionFeed {
     )
 
     /** Fetch and parse [url]. Returns an empty list on any failure (Projectivy
-     *  keeps the current wallpaper rather than crashing). */
+     *  keeps the current wallpaper rather than crashing). Results are cached
+     *  for [CACHE_TTL_MS] so repeat binds don't re-hit the network. */
+    @Synchronized
     fun load(url: String): List<Wallpaper> {
         val resolved = url.ifBlank { DEFAULT_FEED_URL }
+
+        val now = System.currentTimeMillis()
+        if (resolved == cachedUrl &&
+            cachedWallpapers.isNotEmpty() &&
+            now - cachedAt < CACHE_TTL_MS
+        ) {
+            return cachedWallpapers
+        }
+
         val host = try {
             URL(resolved).host
         } catch (_: Exception) {
@@ -43,15 +69,15 @@ object MotionFeed {
             return emptyList()
         }
 
-        return try {
+        val fetched = try {
             val conn = URL(resolved).openConnection() as HttpURLConnection
-            conn.connectTimeout = TIMEOUT_MS
-            conn.readTimeout = TIMEOUT_MS
+            conn.connectTimeout = CONNECT_TIMEOUT_MS
+            conn.readTimeout = READ_TIMEOUT_MS
             conn.instanceFollowRedirects = true
             try {
                 if (conn.responseCode !in 200..299) {
                     Log.w(TAG, "feed HTTP ${conn.responseCode}")
-                    return emptyList()
+                    return staleOrEmpty(resolved)
                 }
                 val body = conn.inputStream.bufferedReader().use { it.readText() }
                 parse(body)
@@ -60,9 +86,22 @@ object MotionFeed {
             }
         } catch (e: Exception) {
             Log.w(TAG, "feed load failed", e)
-            emptyList()
+            return staleOrEmpty(resolved)
         }
+
+        if (fetched.isNotEmpty()) {
+            cachedUrl = resolved
+            cachedAt = now
+            cachedWallpapers = fetched
+        }
+        Log.i(TAG, "feed loaded: ${fetched.size} wallpapers from $resolved")
+        return fetched
     }
+
+    /** On a transient failure, serving the last good batch beats serving
+     *  nothing — an empty list makes the plugin look dead in Projectivy. */
+    private fun staleOrEmpty(url: String): List<Wallpaper> =
+        if (url == cachedUrl) cachedWallpapers else emptyList()
 
     private fun parse(json: String): List<Wallpaper> {
         return try {

--- a/motion-plugin/app/src/main/java/tv/corebuilds/motion/SettingsFragment.kt
+++ b/motion-plugin/app/src/main/java/tv/corebuilds/motion/SettingsFragment.kt
@@ -7,9 +7,11 @@ import androidx.leanback.widget.GuidanceStylist.Guidance
 import androidx.leanback.widget.GuidedAction
 
 /**
- * One editable field: the feed URL. Defaults to the Core Builds live-wallpaper
- * feed; a user can point it at any Overflight-compatible JSON source (their own
- * footage, a local server, etc.).
+ * Two things: the feed URL, and a discovery self-check.
+ *
+ * The self-check runs the same `queryIntentServices` Projectivy runs, so a user
+ * who reports "the plugin isn't detected" can read the answer off the screen
+ * instead of guessing. See docs/PROJECTIVY_DETECTION.md.
  */
 class SettingsFragment : GuidedStepSupportFragment() {
 
@@ -32,20 +34,64 @@ class SettingsFragment : GuidedStepSupportFragment() {
                 .descriptionEditable(true)
                 .build(),
         )
+
+        val report = Diagnostics.run(requireContext())
+        actions.add(
+            GuidedAction.Builder(context)
+                .id(ACTION_ID_DIAGNOSTICS)
+                .title(
+                    getString(
+                        if (report.allPassed) {
+                            R.string.diagnostics_title_ok
+                        } else {
+                            R.string.diagnostics_title_problem
+                        },
+                    ),
+                )
+                .description(report.render())
+                .multilineDescription(true)
+                .infoOnly(false)
+                .focusable(true)
+                .build(),
+        )
     }
 
     override fun onGuidedActionClicked(action: GuidedAction) {
-        if (action.id != ACTION_ID_FEED_URL) return
-        val url = action.editDescription?.toString().orEmpty()
-        Preferences.setFeedUrl(requireContext(), url)
-        findActionById(ACTION_ID_FEED_URL)?.let { a ->
-            a.description = url
-            notifyActionChanged(findActionPositionById(ACTION_ID_FEED_URL))
+        when (action.id) {
+            ACTION_ID_FEED_URL -> {
+                val url = action.editDescription?.toString().orEmpty()
+                Preferences.setFeedUrl(requireContext(), url)
+                findActionById(ACTION_ID_FEED_URL)?.let { a ->
+                    a.description = url
+                    notifyActionChanged(findActionPositionById(ACTION_ID_FEED_URL))
+                }
+                (activity as? SettingsActivity)?.requestWallpaperUpdate()
+                refreshDiagnostics()
+            }
+
+            // Re-run the check on demand — useful right after installing
+            // Projectivy, or after a force-stop.
+            ACTION_ID_DIAGNOSTICS -> refreshDiagnostics()
         }
-        (activity as? SettingsActivity)?.requestWallpaperUpdate()
+    }
+
+    private fun refreshDiagnostics() {
+        val report = Diagnostics.run(requireContext())
+        findActionById(ACTION_ID_DIAGNOSTICS)?.let { a ->
+            a.title = getString(
+                if (report.allPassed) {
+                    R.string.diagnostics_title_ok
+                } else {
+                    R.string.diagnostics_title_problem
+                },
+            )
+            a.description = report.render()
+            notifyActionChanged(findActionPositionById(ACTION_ID_DIAGNOSTICS))
+        }
     }
 
     companion object {
         private const val ACTION_ID_FEED_URL = 1L
+        private const val ACTION_ID_DIAGNOSTICS = 2L
     }
 }

--- a/motion-plugin/app/src/main/java/tv/corebuilds/motion/WallpaperProviderService.kt
+++ b/motion-plugin/app/src/main/java/tv/corebuilds/motion/WallpaperProviderService.kt
@@ -3,6 +3,7 @@ package tv.corebuilds.motion
 import android.app.Service
 import android.content.Intent
 import android.os.IBinder
+import android.util.Log
 import tv.projectivy.plugin.wallpaperprovider.api.Event
 import tv.projectivy.plugin.wallpaperprovider.api.IWallpaperProviderService
 import tv.projectivy.plugin.wallpaperprovider.api.Wallpaper
@@ -14,18 +15,39 @@ import tv.projectivy.plugin.wallpaperprovider.api.Wallpaper
  * feed as a list of [Wallpaper] video objects; Projectivy caches them and
  * cycles through on the user's interval. This is the same contract Overflight
  * and every other wallpaper provider implements.
+ *
+ * The logging here is deliberate: when a plugin "isn't detected", the first
+ * question is whether Projectivy ever bound to it at all. `adb logcat -s
+ * CoreMotion` now answers that in one line.
  */
 class WallpaperProviderService : Service() {
 
-    override fun onBind(intent: Intent): IBinder = binder
+    override fun onBind(intent: Intent): IBinder {
+        Log.i(TAG, "bound by ${callingPackageLabel()} action=${intent.action}")
+        return binder
+    }
+
+    override fun onUnbind(intent: Intent?): Boolean {
+        Log.i(TAG, "unbound")
+        return super.onUnbind(intent)
+    }
+
+    private fun callingPackageLabel(): String =
+        packageManager.getNameForUid(android.os.Binder.getCallingUid()) ?: "unknown"
 
     private val binder = object : IWallpaperProviderService.Stub() {
         override fun getWallpapers(event: Event?): List<Wallpaper> {
             // A static feed doesn't care which event fired; return the set on
             // every request and let Projectivy's cache + interval do the pacing.
             // Bundled Lottie vector loops come first, then the video feed.
-            return BundledAnimations.list(this@WallpaperProviderService) +
-                MotionFeed.load(Preferences.feedUrl(this@WallpaperProviderService))
+            val bundled = BundledAnimations.list(this@WallpaperProviderService)
+            val remote = MotionFeed.load(Preferences.feedUrl(this@WallpaperProviderService))
+            Log.i(
+                TAG,
+                "getWallpapers(event=${event?.eventType}) -> " +
+                    "${bundled.size} bundled + ${remote.size} feed",
+            )
+            return bundled + remote
         }
 
         override fun getPreferences(): String =
@@ -34,5 +56,9 @@ class WallpaperProviderService : Service() {
         override fun setPreferences(params: String) {
             Preferences.import(this@WallpaperProviderService, params)
         }
+    }
+
+    companion object {
+        private const val TAG = "CoreMotion"
     }
 }

--- a/motion-plugin/app/src/main/res/values/strings.xml
+++ b/motion-plugin/app/src/main/res/values/strings.xml
@@ -8,4 +8,8 @@
 
     <string name="settings">Settings</string>
     <string name="setting_feed_url_title">Feed URL</string>
+
+    <!-- Discovery self-check shown in the plugin's settings screen. -->
+    <string name="diagnostics_title_ok">Projectivy discovery — OK</string>
+    <string name="diagnostics_title_problem">Projectivy discovery — problem found</string>
 </resources>

--- a/shift/app/src/main/AndroidManifest.xml
+++ b/shift/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
     <uses-permission
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         android:maxSdkVersion="28" />
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 
     <uses-feature
         android:name="android.hardware.touchscreen"
@@ -43,5 +44,16 @@
             android:label="@string/preview_title"
             android:theme="@style/Theme.CoreShift"
             android:configChanges="orientation|screenSize|keyboardHidden" />
+
+        <!-- In-app updater. Authority must match UpdateInstaller.AUTHORITY. -->
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="dev.corebuilds.shift.update"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
     </application>
 </manifest>

--- a/shift/app/src/main/java/dev/corebuilds/shift/CoreSpectrum.kt
+++ b/shift/app/src/main/java/dev/corebuilds/shift/CoreSpectrum.kt
@@ -1,0 +1,94 @@
+package dev.corebuilds.shift
+
+import android.animation.ArgbEvaluator
+import android.animation.ValueAnimator
+import android.graphics.drawable.GradientDrawable
+import android.view.View
+import android.view.animation.LinearInterpolator
+
+/**
+ * The Core Builds wallpaper palette, and the shared "spectrum" motion built on
+ * it.
+ *
+ * The wallpaper collection (Wallpapers/README.md, 70 pieces) is built from one
+ * ordered ramp — cyan through build blue into dusk violet, with ember as the
+ * warm counterweight. Core Shift's focus and header motion runs that same ramp
+ * so the app reads as part of the suite rather than a generic list. Every
+ * animated colour in the app comes from here; nothing hardcodes a hex.
+ */
+object CoreSpectrum {
+
+    /** The suite ramp, in the order the wallpapers traverse it. */
+    val RAMP = intArrayOf(
+        0xFF00E5FF.toInt(), // Core Cyan
+        0xFF00D4FF.toInt(), // Signal
+        0xFF7EEEFF.toInt(), // Glow
+        0xFF4FACFE.toInt(), // Build Blue
+        0xFF8A4890.toInt(), // Dusk Violet
+        0xFFC03A20.toInt(), // Ember
+    )
+
+    /** The cool half of the ramp — used where ember would be too loud. */
+    val COOL_RAMP = intArrayOf(
+        0xFF00E5FF.toInt(),
+        0xFF7EEEFF.toInt(),
+        0xFF4FACFE.toInt(),
+        0xFF8A4890.toInt(),
+    )
+
+    private val ARGB = ArgbEvaluator()
+
+    /**
+     * Colour at [t] (0..1, wrapping) along [ramp], interpolated. Driving a
+     * single 0..1 phase through this is what makes the border, the spine and
+     * the header rule all move as one system.
+     */
+    fun sample(ramp: IntArray, t: Float): Int {
+        val wrapped = ((t % 1f) + 1f) % 1f
+        val scaled = wrapped * ramp.size
+        val i = scaled.toInt() % ramp.size
+        val next = (i + 1) % ramp.size
+        val frac = scaled - scaled.toInt()
+        return ARGB.evaluate(frac, ramp[i], ramp[next]) as Int
+    }
+
+    /**
+     * A never-ending 0..1 phase animator at [periodMs] per full traversal.
+     * Callers own the lifecycle — start on focus/attach, cancel on blur/recycle.
+     */
+    fun phaseAnimator(periodMs: Long, onPhase: (Float) -> Unit): ValueAnimator =
+        ValueAnimator.ofFloat(0f, 1f).apply {
+            duration = periodMs
+            repeatCount = ValueAnimator.INFINITE
+            interpolator = LinearInterpolator()
+            addUpdateListener { onPhase(it.animatedFraction) }
+        }
+
+    /**
+     * Binds a horizontal spectrum sweep to [view]'s background. Returns the
+     * animator so the caller can cancel it; TV apps leak animators easily and a
+     * running ValueAnimator holds a hard reference to the view.
+     */
+    fun bindSweep(
+        view: View,
+        ramp: IntArray = RAMP,
+        periodMs: Long = 9_000L,
+        cornerRadiusPx: Float = 0f,
+    ): ValueAnimator {
+        val drawable = GradientDrawable().apply {
+            orientation = GradientDrawable.Orientation.LEFT_RIGHT
+            cornerRadius = cornerRadiusPx
+        }
+        view.background = drawable
+
+        // Three samples 1/3 apart give a continuously travelling gradient
+        // rather than a crossfade between two flat colours.
+        return phaseAnimator(periodMs) { phase ->
+            drawable.colors = intArrayOf(
+                sample(ramp, phase),
+                sample(ramp, phase + 0.33f),
+                sample(ramp, phase + 0.66f),
+            )
+        }.also { it.start() }
+    }
+}

--- a/shift/app/src/main/java/dev/corebuilds/shift/LiveAdapter.kt
+++ b/shift/app/src/main/java/dev/corebuilds/shift/LiveAdapter.kt
@@ -14,6 +14,11 @@ import androidx.recyclerview.widget.RecyclerView
  * Rows of the live-wallpaper browser: bundled poster thumb, title, spec, and
  * [Preview] + [Download] buttons. Per-position state so RecyclerView reuse
  * never mislabels an item.
+ *
+ * Focus motion lives in [RowMotion]. Note that the *row* is never focusable —
+ * the two buttons are — so the card's focused appearance is driven from the
+ * children's focus listeners rather than from a state selector, which would
+ * never see `state_focused` on the parent.
  */
 class LiveAdapter(
     private val items: List<LiveEntry>,
@@ -25,12 +30,29 @@ class LiveAdapter(
     private val busy = HashSet<Int>()
 
     class Holder(view: View) : RecyclerView.ViewHolder(view) {
+        val card: View = view.findViewById(R.id.card)
+        val spine: View = view.findViewById(R.id.spine)
         val thumb: ImageView = view.findViewById(R.id.thumb)
         val title: TextView = view.findViewById(R.id.title)
         val spec: TextView = view.findViewById(R.id.spec)
         val status: TextView = view.findViewById(R.id.status)
         val btnPreview: Button = view.findViewById(R.id.btn_preview)
         val btnDownload: Button = view.findViewById(R.id.btn_download)
+
+        val motion = RowMotion(card, spine, thumb)
+
+        init {
+            // Either button holding focus means "this row is the active one".
+            // Posting defers the read until focus has actually settled, so
+            // moving between the two buttons in a row doesn't flicker the card.
+            val listener = View.OnFocusChangeListener { _, _ ->
+                view.post {
+                    motion.setFocused(btnPreview.hasFocus() || btnDownload.hasFocus())
+                }
+            }
+            btnPreview.onFocusChangeListener = listener
+            btnDownload.onFocusChangeListener = listener
+        }
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): Holder =
@@ -55,6 +77,12 @@ class LiveAdapter(
             }
         }
 
+        // Snap, don't animate: a recycled row must not replay a focus enter.
+        holder.motion.setFocused(
+            holder.btnPreview.hasFocus() || holder.btnDownload.hasFocus(),
+            animate = false,
+        )
+
         holder.btnPreview.setOnClickListener {
             val intent = Intent(ctx, PreviewActivity::class.java)
                 .putExtra(PreviewActivity.EXTRA_URL, item.url1080p)
@@ -69,29 +97,66 @@ class LiveAdapter(
         holder.btnDownload.setOnClickListener { onDownload(item, position) }
     }
 
+    override fun onViewRecycled(holder: Holder) {
+        // Animators hold hard references to their targets; a recycled row that
+        // is still sweeping will keep painting into whatever it gets rebound to.
+        holder.motion.release()
+        super.onViewRecycled(holder)
+    }
+
     override fun getItemCount(): Int = items.size
 
     fun setStatus(position: Int, text: String) {
         statuses[position] = text
-        notifyItemChanged(position)
+        notifyItemChanged(position, PAYLOAD_STATUS)
     }
 
     fun markBusy(position: Int) {
         busy.add(position)
         statuses[position] = ""
-        notifyItemChanged(position)
+        notifyItemChanged(position, PAYLOAD_STATUS)
     }
 
     fun markSaved(position: Int, text: String) {
         saved.add(position)
         busy.remove(position)
         statuses[position] = text
-        notifyItemChanged(position)
+        notifyItemChanged(position, PAYLOAD_STATUS)
     }
 
     fun markFailed(position: Int, text: String) {
         busy.remove(position)
         statuses[position] = text
-        notifyItemChanged(position)
+        notifyItemChanged(position, PAYLOAD_STATUS)
+    }
+
+    /**
+     * Partial rebind for status changes.
+     *
+     * Without this, a full [onBindViewHolder] during a download tears down and
+     * rebuilds the row — which drops focus and kills the focus animation
+     * mid-flight, exactly when the user is watching it. Payload binds touch
+     * only the text.
+     */
+    override fun onBindViewHolder(holder: Holder, position: Int, payloads: MutableList<Any>) {
+        if (payloads.contains(PAYLOAD_STATUS)) {
+            val ctx = holder.itemView.context
+            holder.status.text = statuses[position] ?: ""
+            val isSaved = saved.contains(position)
+            val isBusy = busy.contains(position)
+            holder.btnDownload.isEnabled = !isSaved && !isBusy
+            holder.btnDownload.text =
+                ctx.getString(if (isSaved) R.string.saved else R.string.download)
+
+            // Fade the status line in rather than popping it.
+            holder.status.alpha = 0f
+            holder.status.animate().alpha(1f).setDuration(180L).start()
+            return
+        }
+        super.onBindViewHolder(holder, position, payloads)
+    }
+
+    private companion object {
+        const val PAYLOAD_STATUS = "status"
     }
 }

--- a/shift/app/src/main/java/dev/corebuilds/shift/MainActivity.kt
+++ b/shift/app/src/main/java/dev/corebuilds/shift/MainActivity.kt
@@ -1,14 +1,17 @@
 package dev.corebuilds.shift
 
+import android.animation.ValueAnimator
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.view.View
+import android.view.animation.AnimationUtils
 import android.widget.Button
 import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import androidx.recyclerview.widget.DefaultItemAnimator
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import java.io.File
@@ -23,19 +26,46 @@ class MainActivity : AppCompatActivity() {
     private var pending: Pair<LiveEntry, Int>? = null
     private var pendingUpdate: UpdateChecker.Result.Available? = null
     private var installOffered = false
+    private var spectrum: ValueAnimator? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
+        // The header rule runs the wallpaper suite's ramp continuously. It is
+        // the only always-on animation in the app; everything else is
+        // focus-driven, which keeps idle CPU near zero on weak TV SoCs.
+        spectrum = CoreSpectrum.bindSweep(
+            findViewById(R.id.spectrum_rule),
+            periodMs = 11_000L,
+            cornerRadiusPx = 2f * resources.displayMetrics.density,
+        )
+
         val list: RecyclerView = findViewById(R.id.live_list)
         list.layoutManager = LinearLayoutManager(this)
+
+        // Rows lift on focus. ViewGroup sorts children by Z since API 21, so
+        // the raised card draws over its neighbours without any custom
+        // child-drawing-order plumbing.
+        list.itemAnimator = DefaultItemAnimator().apply {
+            addDuration = 200L
+            removeDuration = 160L
+            moveDuration = 200L
+            // Status updates are payload binds; a change animation on top of
+            // them would cross-fade two copies of the row over the focus ring.
+            changeDuration = 0L
+            supportsChangeAnimations = false
+        }
+        list.layoutAnimation =
+            AnimationUtils.loadLayoutAnimation(this, R.anim.live_layout_stagger)
 
         val entries = LiveCatalog.load(this)
         adapter = LiveAdapter(entries) { entry, pos -> download(entry, pos) }
         list.adapter = adapter
+        list.scheduleLayoutAnimation()
 
         if (entries.isEmpty()) {
+            list.visibility = View.GONE
             findViewById<TextView>(R.id.empty).visibility = View.VISIBLE
         }
 
@@ -165,6 +195,8 @@ class MainActivity : AppCompatActivity() {
     }
 
     override fun onDestroy() {
+        spectrum?.cancel()
+        spectrum = null
         io.shutdown()
         super.onDestroy()
     }

--- a/shift/app/src/main/java/dev/corebuilds/shift/MainActivity.kt
+++ b/shift/app/src/main/java/dev/corebuilds/shift/MainActivity.kt
@@ -3,20 +3,17 @@ package dev.corebuilds.shift
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import android.view.View
+import android.widget.Button
+import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import java.io.File
 import java.util.concurrent.Executors
 
-/**
- * Core Shift — the Core Builds live-wallpaper browser.
- *
- * Lists the Core Motion loops, plays each full-screen ([PreviewActivity]), and
- * downloads them to `Movies/CoreBuilds` for Monet. The Projectivy-native route
- * is the Core Motion plugin; this app covers preview + Monet folder delivery.
- */
 class MainActivity : AppCompatActivity() {
 
     private lateinit var adapter: LiveAdapter
@@ -24,6 +21,8 @@ class MainActivity : AppCompatActivity() {
     private val main = Handler(Looper.getMainLooper())
 
     private var pending: Pair<LiveEntry, Int>? = null
+    private var pendingUpdate: UpdateChecker.Result.Available? = null
+    private var installOffered = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -37,7 +36,80 @@ class MainActivity : AppCompatActivity() {
         list.adapter = adapter
 
         if (entries.isEmpty()) {
-            findViewById<TextView>(R.id.empty).visibility = android.view.View.VISIBLE
+            findViewById<TextView>(R.id.empty).visibility = View.VISIBLE
+        }
+
+        checkForUpdate()
+    }
+
+    private fun checkForUpdate() {
+        UpdateChecker.check(this) { result ->
+            when (result) {
+                is UpdateChecker.Result.Available -> showUpdateAvailable(result)
+                is UpdateChecker.Result.UpToDate -> { }
+                is UpdateChecker.Result.Failed -> { }
+            }
+        }
+    }
+
+    private fun showUpdateAvailable(update: UpdateChecker.Result.Available) {
+        pendingUpdate = update
+        val banner: LinearLayout = findViewById(R.id.update_banner)
+        val text: TextView = findViewById(R.id.update_text)
+        val btn: Button = findViewById(R.id.update_btn)
+
+        text.text = getString(R.string.update_available, update.versionName)
+        banner.visibility = View.VISIBLE
+
+        btn.setOnClickListener { startUpdateDownload(update) }
+    }
+
+    private fun startUpdateDownload(update: UpdateChecker.Result.Available) {
+        val text: TextView = findViewById(R.id.update_text)
+        val btn: Button = findViewById(R.id.update_btn)
+        btn.isEnabled = false
+        text.text = getString(R.string.update_downloading)
+
+        UpdateInstaller.download(this, update.apkUrl) { event ->
+            when (event) {
+                is UpdateInstaller.Event.Progress -> {
+                    if (event.total > 0) {
+                        val pct = (event.received * 100 / event.total).toInt()
+                        text.text = "$pct%"
+                    }
+                }
+                is UpdateInstaller.Event.Ready -> {
+                    text.text = getString(R.string.update_installing)
+                    promptInstall(event.file)
+                }
+                is UpdateInstaller.Event.Failed -> {
+                    text.text = getString(R.string.update_failed_fmt, event.reason)
+                    btn.isEnabled = true
+                    btn.text = getString(R.string.update_btn)
+                }
+            }
+        }
+    }
+
+    private fun promptInstall(file: File) {
+        if (!UpdateInstaller.canInstall(this)) {
+            val text: TextView = findViewById(R.id.update_text)
+            text.text = getString(R.string.update_permission)
+            if (!UpdateInstaller.requestInstallPermission(this)) {
+                Toast.makeText(this, getString(R.string.update_permission), Toast.LENGTH_LONG).show()
+            }
+            return
+        }
+        installOffered = true
+        UpdateInstaller.install(this, file)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        val updateFile = File(cacheDir, "updates/coreshift-update.apk")
+        if (updateFile.exists() && UpdateInstaller.canInstall(this) && !installOffered) {
+            installOffered = true
+            UpdateInstaller.install(this, updateFile)
         }
     }
 

--- a/shift/app/src/main/java/dev/corebuilds/shift/RowMotion.kt
+++ b/shift/app/src/main/java/dev/corebuilds/shift/RowMotion.kt
@@ -1,0 +1,241 @@
+package dev.corebuilds.shift
+
+import android.animation.ValueAnimator
+import android.graphics.ColorMatrix
+import android.graphics.ColorMatrixColorFilter
+import android.graphics.drawable.GradientDrawable
+import android.view.View
+import android.view.animation.DecelerateInterpolator
+import android.widget.ImageView
+import androidx.core.view.ViewCompat
+
+/**
+ * Focus motion for a live-wallpaper row.
+ *
+ * On a TV there is exactly one focused thing and the user is six feet away, so
+ * focus has to be unmistakable without being noisy. This does four things at
+ * once, all off a single state change:
+ *
+ *  - the card lifts (scale + elevation) on a decelerate curve;
+ *  - its border runs the wallpaper suite's cyan→violet ramp, travelling;
+ *  - the leading accent spine wipes in from the top;
+ *  - the poster thumb saturates from 45% to full and slowly drifts (ken burns),
+ *    which is what makes a still thumbnail read as "this one is alive".
+ *
+ * Unfocused rows are deliberately desaturated: with ten cyan-heavy thumbs in a
+ * column, saturating only the focused one is what creates the depth.
+ *
+ * Every animator is owned and cancelled — see [release]. A running ValueAnimator
+ * holds a hard reference to its target, and RecyclerView will recycle these
+ * rows out from under us.
+ */
+class RowMotion(
+    private val card: View,
+    private val spine: View,
+    private val thumb: ImageView,
+) {
+
+    private val density = card.resources.displayMetrics.density
+    private val cornerRadius = 12f * density
+    private val strokeWidth = (2f * density).toInt()
+    private val liftZ = 10f * density
+
+    private val surface = card.context.getColor(R.color.cb_surface)
+    private val surfaceFocused = card.context.getColor(R.color.cb_surface_focused)
+
+    /** The card background is built in code so the stroke colour can animate;
+     *  a selector drawable can only cut between static states. */
+    private val background = GradientDrawable().apply {
+        shape = GradientDrawable.RECTANGLE
+        cornerRadius = this@RowMotion.cornerRadius
+        setColor(surface)
+        setStroke(strokeWidth, 0x00000000)
+    }
+
+    private val spineDrawable = GradientDrawable().apply {
+        orientation = GradientDrawable.Orientation.TOP_BOTTOM
+        cornerRadius = 2f * density
+    }
+
+    private var sweep: ValueAnimator? = null
+    private var kenBurns: ValueAnimator? = null
+    private var lift: ValueAnimator? = null
+
+    private var focused = false
+    private var currentSaturation = RESTING_SATURATION
+
+    init {
+        card.background = background
+        card.clipToOutline = false
+        spine.background = spineDrawable
+        spine.alpha = 0f
+        spine.scaleY = 0.2f
+        spine.pivotY = 0f
+        applyThumbSaturation(RESTING_SATURATION)
+    }
+
+    /**
+     * @param animate false on (re)bind, so a recycled row snaps to the right
+     *        state instead of playing a phantom focus animation.
+     */
+    fun setFocused(value: Boolean, animate: Boolean = true) {
+        if (focused == value && animate) return
+        focused = value
+        if (value) enter(animate) else exit(animate)
+    }
+
+    private fun enter(animate: Boolean) {
+        card.pivotX = 0f
+        card.pivotY = card.height / 2f
+
+        // Travelling border + spine, both off the same phase so they read as
+        // one light source moving across the card.
+        sweep?.cancel()
+        sweep = CoreSpectrum.phaseAnimator(SWEEP_PERIOD_MS) { phase ->
+            background.setStroke(strokeWidth, CoreSpectrum.sample(CoreSpectrum.COOL_RAMP, phase))
+            spineDrawable.colors = intArrayOf(
+                CoreSpectrum.sample(CoreSpectrum.COOL_RAMP, phase),
+                CoreSpectrum.sample(CoreSpectrum.COOL_RAMP, phase + 0.4f),
+            )
+        }.also { it.start() }
+
+        background.setColor(surfaceFocused)
+
+        animateLift(
+            toScale = FOCUSED_SCALE,
+            toZ = liftZ,
+            toSaturation = 1f,
+            duration = if (animate) ENTER_MS else 0L,
+        )
+
+        spine.animate()
+            .alpha(1f).scaleY(1f)
+            .setDuration(if (animate) ENTER_MS else 0L)
+            .setInterpolator(DECELERATE)
+            .start()
+
+        // Slow continuous drift on the poster. Long period + small amplitude:
+        // it should be felt, not watched.
+        kenBurns?.cancel()
+        kenBurns = ValueAnimator.ofFloat(1f, THUMB_DRIFT_SCALE).apply {
+            duration = KEN_BURNS_MS
+            repeatCount = ValueAnimator.INFINITE
+            repeatMode = ValueAnimator.REVERSE
+            addUpdateListener {
+                val s = it.animatedValue as Float
+                thumb.scaleX = s
+                thumb.scaleY = s
+            }
+            start()
+        }
+    }
+
+    private fun exit(animate: Boolean) {
+        sweep?.cancel()
+        sweep = null
+        kenBurns?.cancel()
+        kenBurns = null
+
+        background.setColor(surface)
+        background.setStroke(strokeWidth, 0x00000000)
+
+        animateLift(
+            toScale = 1f,
+            toZ = 0f,
+            toSaturation = RESTING_SATURATION,
+            duration = if (animate) EXIT_MS else 0L,
+        )
+
+        spine.animate()
+            .alpha(0f).scaleY(0.2f)
+            .setDuration(if (animate) EXIT_MS else 0L)
+            .setInterpolator(DECELERATE)
+            .start()
+
+        thumb.animate()
+            .scaleX(1f).scaleY(1f)
+            .setDuration(if (animate) EXIT_MS else 0L)
+            .start()
+    }
+
+    /** Scale, elevation and thumb saturation share one animator — three
+     *  separate ones drift apart on a slow TV SoC and the card looks rubbery. */
+    private fun animateLift(
+        toScale: Float,
+        toZ: Float,
+        toSaturation: Float,
+        duration: Long,
+    ) {
+        lift?.cancel()
+
+        val fromScale = card.scaleX
+        val fromZ = ViewCompat.getTranslationZ(card)
+        val fromSaturation = currentSaturation
+
+        if (duration == 0L) {
+            applyLift(toScale, toZ, toSaturation)
+            return
+        }
+
+        lift = ValueAnimator.ofFloat(0f, 1f).apply {
+            this.duration = duration
+            interpolator = DECELERATE
+            addUpdateListener {
+                val f = it.animatedFraction
+                applyLift(
+                    fromScale + (toScale - fromScale) * f,
+                    fromZ + (toZ - fromZ) * f,
+                    fromSaturation + (toSaturation - fromSaturation) * f,
+                )
+            }
+            start()
+        }
+    }
+
+    private fun applyLift(scale: Float, z: Float, saturation: Float) {
+        card.scaleX = scale
+        card.scaleY = scale
+        ViewCompat.setTranslationZ(card, z)
+        applyThumbSaturation(saturation)
+    }
+
+    private fun applyThumbSaturation(value: Float) {
+        currentSaturation = value
+        thumb.colorFilter = if (value >= 0.999f) {
+            null
+        } else {
+            ColorMatrixColorFilter(ColorMatrix().apply { setSaturation(value) })
+        }
+        // A touch of dimming on resting rows, so focus also reads as brightness.
+        thumb.alpha = 0.80f + 0.20f * value
+    }
+
+    /** Must be called from onViewRecycled / onViewDetachedFromWindow. */
+    fun release() {
+        sweep?.cancel(); sweep = null
+        kenBurns?.cancel(); kenBurns = null
+        lift?.cancel(); lift = null
+        card.animate().cancel()
+        spine.animate().cancel()
+        thumb.animate().cancel()
+        focused = false
+        applyLift(1f, 0f, RESTING_SATURATION)
+        thumb.scaleX = 1f
+        thumb.scaleY = 1f
+        spine.alpha = 0f
+        spine.scaleY = 0.2f
+        background.setColor(surface)
+        background.setStroke(strokeWidth, 0x00000000)
+    }
+
+    private companion object {
+        const val FOCUSED_SCALE = 1.03f
+        const val THUMB_DRIFT_SCALE = 1.07f
+        const val RESTING_SATURATION = 0.45f
+        const val ENTER_MS = 220L
+        const val EXIT_MS = 180L
+        const val SWEEP_PERIOD_MS = 7_000L
+        const val KEN_BURNS_MS = 6_000L
+        val DECELERATE = DecelerateInterpolator(1.6f)
+    }
+}

--- a/shift/app/src/main/java/dev/corebuilds/shift/UpdateChecker.kt
+++ b/shift/app/src/main/java/dev/corebuilds/shift/UpdateChecker.kt
@@ -1,0 +1,101 @@
+package dev.corebuilds.shift
+
+import android.content.Context
+import android.util.Log
+import org.json.JSONObject
+import java.net.HttpURLConnection
+import java.net.URL
+import java.util.concurrent.Executors
+
+object UpdateChecker {
+
+    private const val TAG = "CoreShiftUpdate"
+    private val MANIFEST_URLS = listOf(
+        "https://raw.githubusercontent.com/brevityA/CoreBuildsApps/" +
+            "main/Latestrelease/shift-version.json",
+        "https://raw.githubusercontent.com/brevityA/CoreBuildsIconPack/" +
+            "main/Latestrelease/shift-version.json"
+    )
+    private const val TIMEOUT_MS = 8000
+
+    sealed class Result {
+        data class Available(
+            val versionName: String,
+            val versionCode: Int,
+            val apkUrl: String
+        ) : Result()
+
+        data class UpToDate(val versionName: String) : Result()
+
+        data class Failed(val reason: String) : Result()
+    }
+
+    private val io = Executors.newSingleThreadExecutor()
+
+    fun check(context: Context, onResult: (Result) -> Unit) {
+        val installed = installedVersionCode(context)
+        io.execute {
+            val result = try {
+                fetch(installed)
+            } catch (e: Exception) {
+                Result.Failed(e.message ?: e.javaClass.simpleName)
+            }
+            android.os.Handler(context.mainLooper).post { onResult(result) }
+        }
+    }
+
+    private fun fetch(installedCode: Int): Result {
+        var lastError: String? = null
+        for (url in MANIFEST_URLS) {
+            var conn: HttpURLConnection? = null
+            try {
+                conn = (URL(url).openConnection() as HttpURLConnection).apply {
+                    connectTimeout = TIMEOUT_MS
+                    readTimeout = TIMEOUT_MS
+                    requestMethod = "GET"
+                    setRequestProperty("Accept", "application/json")
+                    setRequestProperty("User-Agent", "CoreShift-Updater")
+                }
+                val code = conn.responseCode
+                if (code != 200) {
+                    lastError = "update manifest returned HTTP $code from $url"
+                    Log.w(TAG, lastError!!)
+                    continue
+                }
+                val body = conn.inputStream.bufferedReader().use { it.readText() }
+                val json = JSONObject(body)
+
+                val remoteCode = json.getInt("versionCode")
+                val remoteName = json.optString("versionName", "?")
+                val apk = json.optString("apkUrl", "")
+
+                Log.i(TAG, "installed=$installedCode remote=$remoteCode from $url")
+
+                return if (remoteCode > installedCode) {
+                    Result.Available(remoteName, remoteCode, apk)
+                } else {
+                    Result.UpToDate(remoteName)
+                }
+            } catch (e: Exception) {
+                lastError = e.message ?: e.javaClass.simpleName
+                Log.w(TAG, "manifest fetch failed $url: $lastError")
+            } finally {
+                try { conn?.disconnect() } catch (_: Exception) {}
+            }
+        }
+        return Result.Failed(lastError ?: "could not fetch update manifest")
+    }
+
+    private fun installedVersionCode(context: Context): Int = try {
+        val pi = context.packageManager.getPackageInfo(context.packageName, 0)
+        @Suppress("DEPRECATION")
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) {
+            pi.longVersionCode.toInt()
+        } else {
+            pi.versionCode
+        }
+    } catch (e: Exception) {
+        Log.w(TAG, "could not read installed version: ${e.message}")
+        0
+    }
+}

--- a/shift/app/src/main/java/dev/corebuilds/shift/UpdateInstaller.kt
+++ b/shift/app/src/main/java/dev/corebuilds/shift/UpdateInstaller.kt
@@ -1,0 +1,167 @@
+package dev.corebuilds.shift
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.provider.Settings
+import androidx.core.content.FileProvider
+import java.io.File
+import java.net.HttpURLConnection
+import java.net.URL
+import java.util.concurrent.Executors
+
+object UpdateInstaller {
+
+    const val AUTHORITY = "dev.corebuilds.shift.update"
+    private const val TIMEOUT_MS = 30_000
+    private const val MIN_APK_BYTES = 200_000L
+    private val ALLOWED_HOSTS = setOf(
+        "github.com",
+        "objects.githubusercontent.com",
+        "release-assets.githubusercontent.com",
+        "github-releases.githubusercontent.com",
+    )
+    private val io = Executors.newSingleThreadExecutor()
+
+    sealed class Event {
+        data class Progress(val received: Long, val total: Long) : Event()
+        data class Ready(val file: File) : Event()
+        data class Failed(val reason: String) : Event()
+    }
+
+    fun download(context: Context, apkUrl: String, onEvent: (Event) -> Unit) {
+        val app = context.applicationContext
+        val main = android.os.Handler(app.mainLooper)
+        io.execute {
+            try {
+                val file = fetchToCache(app, apkUrl) { rec, tot ->
+                    main.post { onEvent(Event.Progress(rec, tot)) }
+                }
+                main.post { onEvent(Event.Ready(file)) }
+            } catch (e: Exception) {
+                main.post {
+                    onEvent(Event.Failed(e.message ?: e.javaClass.simpleName))
+                }
+            }
+        }
+    }
+
+    fun canInstall(context: Context): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            context.packageManager.canRequestPackageInstalls()
+        } else {
+            true
+        }
+    }
+
+    fun requestInstallPermission(context: Context): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return false
+        val intent = Intent(
+            Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES,
+            Uri.parse("package:${context.packageName}")
+        ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        return try {
+            context.startActivity(intent)
+            true
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    fun install(context: Context, file: File) {
+        val uri = FileProvider.getUriForFile(context, AUTHORITY, file)
+        val intent = Intent(Intent.ACTION_VIEW).apply {
+            setDataAndType(uri, "application/vnd.android.package-archive")
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        context.startActivity(intent)
+    }
+
+    private fun fetchToCache(
+        context: Context,
+        apkUrl: String,
+        onProgress: (Long, Long) -> Unit
+    ): File {
+        val dir = File(context.cacheDir, "updates").apply { mkdirs() }
+        val dest = File(dir, "coreshift-update.apk")
+        if (dest.exists()) dest.delete()
+
+        val start = URL(apkUrl)
+        if (start.protocol != "https") {
+            throw IllegalStateException("APK URL must be https")
+        }
+        if (start.host !in ALLOWED_HOSTS) {
+            throw IllegalStateException("APK host ${start.host} is not GitHub")
+        }
+        var url = apkUrl
+        var conn: HttpURLConnection? = null
+        repeat(6) {
+            val nextUrl = URL(url)
+            if (nextUrl.protocol != "https" || nextUrl.host !in ALLOWED_HOSTS) {
+                throw IllegalStateException("redirect left GitHub ($url)")
+            }
+            conn = (nextUrl.openConnection() as HttpURLConnection).apply {
+                instanceFollowRedirects = false
+                connectTimeout = TIMEOUT_MS
+                readTimeout = TIMEOUT_MS
+                requestMethod = "GET"
+                setRequestProperty("Accept", "application/vnd.android.package-archive,*/*")
+                setRequestProperty("User-Agent", "CoreShift-Updater")
+            }
+            val code = conn!!.responseCode
+            if (code in 300..399) {
+                val next = conn!!.getHeaderField("Location")
+                    ?: throw IllegalStateException("redirect $code with no Location")
+                conn!!.disconnect()
+                url = if (next.startsWith("http")) next else URL(URL(url), next).toString()
+            } else if (code == 200) {
+                return@repeat
+            } else {
+                throw IllegalStateException("APK download returned HTTP $code")
+            }
+        }
+        val c = conn ?: throw IllegalStateException("could not open $apkUrl")
+        try {
+            if (c.responseCode != 200) {
+                throw IllegalStateException("APK download returned HTTP ${c.responseCode}")
+            }
+            val total = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                c.contentLengthLong
+            } else {
+                @Suppress("DEPRECATION")
+                c.contentLength.toLong()
+            }.let { if (it > 0) it else -1L }
+            var received = 0L
+            c.inputStream.use { input ->
+                dest.outputStream().use { output ->
+                    val buf = ByteArray(16 * 1024)
+                    while (true) {
+                        val n = input.read(buf)
+                        if (n <= 0) break
+                        output.write(buf, 0, n)
+                        received += n
+                        onProgress(received, total)
+                    }
+                }
+            }
+            if (received < MIN_APK_BYTES) {
+                dest.delete()
+                throw IllegalStateException(
+                    "downloaded ${received}B — too small to be an APK"
+                )
+            }
+            val header = dest.inputStream().use { s ->
+                val b = ByteArray(2); s.read(b); b
+            }
+            if (header[0] != 0x50.toByte() || header[1] != 0x4B.toByte()) {
+                dest.delete()
+                throw IllegalStateException("not a ZIP/APK (bad magic)")
+            }
+            return dest
+        } finally {
+            c.disconnect()
+        }
+    }
+}

--- a/shift/app/src/main/res/anim/live_item_rise.xml
+++ b/shift/app/src/main/res/anim/live_item_rise.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Row entry: rise + fade + a whisper of scale. Short and decelerating so a
+     ten-item list settles fast rather than making the user wait for choreography. -->
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="300"
+    android:interpolator="@android:interpolator/decelerate_quint">
+
+    <alpha
+        android:fromAlpha="0.0"
+        android:toAlpha="1.0" />
+
+    <translate
+        android:fromYDelta="18%"
+        android:toYDelta="0" />
+
+    <scale
+        android:fromXScale="0.97"
+        android:toXScale="1.0"
+        android:fromYScale="0.97"
+        android:toYScale="1.0"
+        android:pivotX="0%"
+        android:pivotY="50%" />
+</set>

--- a/shift/app/src/main/res/anim/live_layout_stagger.xml
+++ b/shift/app/src/main/res/anim/live_layout_stagger.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Staggered cascade down the list. 12% delay keeps the whole run under ~700ms
+     for the ten Core Motion loops. -->
+<layoutAnimation xmlns:android="http://schemas.android.com/apk/res/android"
+    android:animation="@anim/live_item_rise"
+    android:animationOrder="normal"
+    android:delay="12%" />

--- a/shift/app/src/main/res/drawable/card_bg.xml
+++ b/shift/app/src/main/res/drawable/card_bg.xml
@@ -1,16 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_focused="true">
-        <shape>
-            <solid android:color="#1B2634" />
-            <stroke android:width="2dp" android:color="@color/cb_cyan" />
-            <corners android:radius="8dp" />
-        </shape>
-    </item>
-    <item>
-        <shape>
-            <solid android:color="@color/cb_surface" />
-            <corners android:radius="8dp" />
-        </shape>
-    </item>
-</selector>
+<!-- Resting card. The focused appearance is built in code (RowMotion) because
+     the border colour travels through the wallpaper suite ramp and a selector
+     can only cut between static states. This stays as the fallback / preview. -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/cb_surface" />
+    <corners android:radius="12dp" />
+</shape>

--- a/shift/app/src/main/res/layout/activity_main.xml
+++ b/shift/app/src/main/res/layout/activity_main.xml
@@ -22,6 +22,37 @@
         android:textColor="@color/cb_text_secondary"
         android:textSize="14sp" />
 
+    <LinearLayout
+        android:id="@+id/update_banner"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
+        android:padding="12dp"
+        android:layout_marginBottom="8dp"
+        android:background="@drawable/card_bg"
+        android:visibility="gone">
+
+        <TextView
+            android:id="@+id/update_text"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:textColor="@color/cb_cyan"
+            android:textSize="15sp" />
+
+        <Button
+            android:id="@+id/update_btn"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:minWidth="100dp"
+            android:text="@string/update_btn"
+            android:textSize="14sp"
+            android:textColor="@color/btn_text"
+            android:background="@drawable/btn_bg"
+            android:focusable="true" />
+    </LinearLayout>
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/live_list"
         android:layout_width="match_parent"

--- a/shift/app/src/main/res/layout/activity_main.xml
+++ b/shift/app/src/main/res/layout/activity_main.xml
@@ -3,9 +3,13 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:padding="24dp">
+    android:paddingStart="24dp"
+    android:paddingEnd="24dp"
+    android:paddingTop="24dp"
+    android:paddingBottom="0dp">
 
     <TextView
+        android:id="@+id/header"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/app_name"
@@ -13,11 +17,20 @@
         android:textSize="28sp"
         android:textStyle="bold" />
 
+    <!-- Spectrum rule: the wallpaper collection's cyan→violet→ember ramp,
+         travelling. It's the app's one piece of ambient motion and it ties the
+         header to the focus colour on the cards below. -->
+    <View
+        android:id="@+id/spectrum_rule"
+        android:layout_width="220dp"
+        android:layout_height="3dp"
+        android:layout_marginTop="6dp" />
+
     <TextView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
-        android:layout_marginBottom="16dp"
+        android:layout_marginTop="10dp"
+        android:layout_marginBottom="12dp"
         android:text="@string/app_hint"
         android:textColor="@color/cb_text_secondary"
         android:textSize="14sp" />
@@ -53,12 +66,18 @@
             android:focusable="true" />
     </LinearLayout>
 
+    <!-- clipChildren/clipToPadding false so a focused card can scale and cast
+         elevation past the list bounds instead of being sliced off. -->
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/live_list"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1"
-        android:clipToPadding="false" />
+        android:clipToPadding="false"
+        android:clipChildren="false"
+        android:paddingStart="6dp"
+        android:paddingEnd="6dp"
+        android:paddingBottom="24dp" />
 
     <TextView
         android:id="@+id/empty"

--- a/shift/app/src/main/res/layout/item_live.xml
+++ b/shift/app/src/main/res/layout/item_live.xml
@@ -1,79 +1,104 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<!-- Row. The outer FrameLayout is the stable measurement box; `card` is what
+     scales and lifts on focus, so neighbouring rows never reflow. -->
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="horizontal"
-    android:gravity="center_vertical"
-    android:padding="12dp"
-    android:layout_marginBottom="8dp"
-    android:background="@drawable/card_bg"
-    android:descendantFocusability="afterDescendants">
-
-    <ImageView
-        android:id="@+id/thumb"
-        android:layout_width="128dp"
-        android:layout_height="72dp"
-        android:scaleType="centerCrop"
-        android:contentDescription="@null" />
+    android:clipChildren="false"
+    android:clipToPadding="false"
+    android:paddingTop="4dp"
+    android:paddingBottom="8dp">
 
     <LinearLayout
-        android:layout_width="0dp"
+        android:id="@+id/card"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:layout_marginStart="16dp"
-        android:orientation="vertical">
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
+        android:paddingTop="12dp"
+        android:paddingBottom="12dp"
+        android:paddingEnd="12dp"
+        android:paddingStart="0dp"
+        android:background="@drawable/card_bg"
+        android:clipChildren="false"
+        android:descendantFocusability="afterDescendants">
 
-        <TextView
-            android:id="@+id/title"
+        <!-- Leading accent spine. Wipes in on focus, running the suite ramp. -->
+        <View
+            android:id="@+id/spine"
+            android:layout_width="4dp"
+            android:layout_height="match_parent"
+            android:layout_marginTop="8dp"
+            android:layout_marginBottom="8dp"
+            android:layout_marginStart="4dp"
+            android:layout_marginEnd="8dp" />
+
+        <ImageView
+            android:id="@+id/thumb"
+            android:layout_width="128dp"
+            android:layout_height="72dp"
+            android:scaleType="centerCrop"
+            android:contentDescription="@null" />
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_marginStart="16dp"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="@color/cb_text_primary"
+                android:textSize="18sp" />
+
+            <TextView
+                android:id="@+id/spec"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:fontFamily="monospace"
+                android:textColor="@color/cb_text_secondary"
+                android:textSize="13sp" />
+
+            <TextView
+                android:id="@+id/status"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:fontFamily="monospace"
+                android:textColor="@color/cb_cyan"
+                android:textSize="13sp" />
+        </LinearLayout>
+
+        <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textColor="@color/cb_text_primary"
-            android:textSize="18sp" />
+            android:orientation="vertical">
 
-        <TextView
-            android:id="@+id/spec"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:fontFamily="monospace"
-            android:textColor="@color/cb_text_secondary"
-            android:textSize="13sp" />
+            <Button
+                android:id="@+id/btn_preview"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:minWidth="120dp"
+                android:text="@string/preview"
+                android:textSize="16sp"
+                android:textColor="@color/btn_text"
+                android:background="@drawable/btn_bg"
+                android:focusable="true"
+                android:nextFocusDown="@id/btn_download" />
 
-        <TextView
-            android:id="@+id/status"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:fontFamily="monospace"
-            android:textColor="@color/cb_cyan"
-            android:textSize="13sp" />
+            <Button
+                android:id="@+id/btn_download"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:minWidth="120dp"
+                android:text="@string/download"
+                android:textSize="16sp"
+                android:textColor="@color/btn_text"
+                android:background="@drawable/btn_bg"
+                android:focusable="true"
+                android:nextFocusUp="@id/btn_preview" />
+        </LinearLayout>
     </LinearLayout>
-
-    <LinearLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="vertical">
-
-        <Button
-            android:id="@+id/btn_preview"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:minWidth="120dp"
-            android:text="@string/preview"
-            android:textSize="16sp"
-            android:textColor="@color/btn_text"
-            android:background="@drawable/btn_bg"
-            android:focusable="true"
-            android:nextFocusDown="@id/btn_download" />
-
-        <Button
-            android:id="@+id/btn_download"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:minWidth="120dp"
-            android:text="@string/download"
-            android:textSize="16sp"
-            android:textColor="@color/btn_text"
-            android:background="@drawable/btn_bg"
-            android:focusable="true"
-            android:nextFocusUp="@id/btn_preview" />
-    </LinearLayout>
-</LinearLayout>
+</FrameLayout>

--- a/shift/app/src/main/res/values/colors.xml
+++ b/shift/app/src/main/res/values/colors.xml
@@ -1,11 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- Core Builds Brand Guide §03 -->
+    <!-- Core Builds Brand Guide §03 — kept in sync with Wallpapers/README.md so
+         the app's motion reads as the same family as the wallpaper collection. -->
     <color name="cb_night">#0D1117</color>
-    <color name="cb_void">#080C10</color>
+    <color name="cb_void">#04070F</color>
     <color name="cb_cyan">#00E5FF</color>
+    <color name="cb_signal">#00D4FF</color>
+    <color name="cb_glow">#7EEEFF</color>
     <color name="cb_build_blue">#4FACFE</color>
+    <color name="cb_violet">#8A4890</color>
+    <color name="cb_ember">#C03A20</color>
     <color name="cb_surface">#161B22</color>
+    <color name="cb_surface_focused">#1B2634</color>
     <color name="cb_text_primary">#E6EDF3</color>
     <color name="cb_text_secondary">#8B949E</color>
     <color name="ic_launcher_background">#0D1117</color>

--- a/shift/app/src/main/res/values/strings.xml
+++ b/shift/app/src/main/res/values/strings.xml
@@ -12,4 +12,11 @@
     <string name="empty">No live wallpapers found</string>
     <string name="preview_loading">Loading…</string>
     <string name="preview_failed">Preview failed</string>
+
+    <string name="update_available">v%1$s available</string>
+    <string name="update_btn">Update</string>
+    <string name="update_downloading">Downloading…</string>
+    <string name="update_installing">Ready — installing…</string>
+    <string name="update_failed_fmt">Update failed · %1$s</string>
+    <string name="update_permission">Allow installs from Core Shift first</string>
 </resources>

--- a/shift/app/src/main/res/xml/file_paths.xml
+++ b/shift/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <cache-path name="updates" path="updates/" />
+</paths>

--- a/tools/build_aerial_feed.py
+++ b/tools/build_aerial_feed.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Emit the Core Motion loops as an Aerial Views "community" feed.
+
+Why this exists
+---------------
+Monet Launcher (com.klevico.monet) is closed source and has no wallpaper
+provider plugin API — nothing like Projectivy's IWallpaperProviderService. Its
+wallpaper sources are fixed: your own images/videos, built-in, Reddit, and
+**Aerial Views**.
+
+Aerial Views (com.neilturner.aerialviews) *does* take arbitrary remote feeds, in
+the "community" entries.json format. So the supported route onto Monet is:
+
+    Motion/aerial-entries.json  ->  Aerial Views (custom feed)  ->  Monet
+
+That gives Monet users the same auto-updating remote catalogue Projectivy users
+get from the Core Motion plugin, without Monet needing to know we exist.
+
+Source of truth stays Motion/live-feed.json (Overflight format). This script is
+a pure projection of it — never hand-edit the output.
+
+Usage:
+    python tools/build_aerial_feed.py           # write Motion/aerial-entries.json
+    python tools/build_aerial_feed.py --check   # verify it is in sync (CI)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SOURCE = ROOT / "Motion" / "live-feed.json"
+TARGET = ROOT / "Motion" / "aerial-entries.json"
+
+# Aerial Views buckets entries by time of day and uses it for playlist filtering.
+# The Core Builds palette is dark-first (Night #0D1117 / Void #04070F), so every
+# loop belongs in the night bucket — putting them in "day" makes Aerial Views
+# skip them for users who filter, which reads as "the feed is broken".
+TIME_OF_DAY = "night"
+
+
+def slugify(url: str, fallback: str) -> str:
+    """Stable id from the filename. Aerial Views keys favourites off `id`, so it
+    must not change when titles are reworded."""
+    name = url.rsplit("/", 1)[-1]
+    name = re.sub(r"\.(mp4|mov|webm)$", "", name, flags=re.IGNORECASE)
+    name = re.sub(r"[^a-zA-Z0-9]+", "_", name).strip("_").lower()
+    return name or re.sub(r"[^a-z0-9]+", "_", fallback.lower()).strip("_")
+
+
+def convert(entries: list[dict]) -> dict:
+    assets = []
+    for e in entries:
+        url_1080 = (e.get("url_1080p") or "").strip()
+        url_4k = (e.get("url_4k") or "").strip()
+        if not url_1080 and not url_4k:
+            continue
+
+        title = (e.get("title") or "Core Motion").strip()
+        location = (e.get("location") or "Core Motion").strip()
+        author = (e.get("author") or "Core Builds").strip()
+
+        asset: dict = {
+            "id": slugify(url_1080 or url_4k, title),
+            # Aerial Views shows this as the on-screen description, so it is the
+            # only place our attribution can surface.
+            "accessibilityLabel": f"{title} — {location} by {author}",
+            "type": "aerial",
+            "timeOfDay": TIME_OF_DAY,
+        }
+        # Only emit the keys we actually have. Aerial Views falls back across
+        # qualities, but an empty-string URL is treated as present and fails.
+        if url_1080:
+            asset["url-1080-SDR"] = url_1080
+        if url_4k:
+            asset["url-4K-SDR"] = url_4k
+
+        assets.append(asset)
+
+    return {"assets": assets}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--check", action="store_true",
+                    help="fail if the generated feed differs from the committed one")
+    args = ap.parse_args()
+
+    if not SOURCE.exists():
+        print(f"error: {SOURCE.relative_to(ROOT)} not found", file=sys.stderr)
+        return 1
+
+    entries = json.loads(SOURCE.read_text())
+    if not isinstance(entries, list):
+        print("error: live-feed.json must be a JSON array", file=sys.stderr)
+        return 1
+
+    feed = convert(entries)
+    rendered = json.dumps(feed, indent=2) + "\n"
+
+    if not feed["assets"]:
+        print("error: produced an empty feed", file=sys.stderr)
+        return 1
+
+    if args.check:
+        if not TARGET.exists():
+            print(f"error: {TARGET.relative_to(ROOT)} is missing — run "
+                  "tools/build_aerial_feed.py", file=sys.stderr)
+            return 1
+        if TARGET.read_text() != rendered:
+            print(f"error: {TARGET.relative_to(ROOT)} is out of sync with "
+                  "live-feed.json — run tools/build_aerial_feed.py", file=sys.stderr)
+            return 1
+        print(f"ok: {TARGET.relative_to(ROOT)} in sync "
+              f"({len(feed['assets'])} assets)")
+        return 0
+
+    TARGET.write_text(rendered)
+    print(f"wrote {TARGET.relative_to(ROOT)} — {len(feed['assets'])} assets")
+    for a in feed["assets"]:
+        tiers = [k.replace("url-", "") for k in a if k.startswith("url-")]
+        print(f"  {a['id']:<38} {'/'.join(tiers)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/verify_motion_plugin.py
+++ b/tools/verify_motion_plugin.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""Verify the Core Motion plugin still satisfies Projectivy's discovery contract.
+
+Projectivy finds a wallpaper provider by running
+
+    queryIntentServices(Intent("tv.projectivy.plugin.WALLPAPER_PROVIDER"), GET_META_DATA)
+
+and then binding over the IWallpaperProviderService AIDL. Two classes of silent
+breakage make a plugin undetectable, and neither shows up as a build failure:
+
+  1. a manifest key drifts (renamed service, meta-data moved to <application>,
+     uuid reset to CHANGE_ME, leanback hard-required again);
+  2. the vendored copy of Spocky's API drifts from upstream, changing the AIDL
+     interface descriptor so the bind succeeds but the transaction doesn't.
+
+This checks both, offline, with no Android SDK. See docs/PROJECTIVY_DETECTION.md.
+
+Usage: python tools/verify_motion_plugin.py
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import sys
+import uuid as uuidlib
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+PLUGIN = ROOT / "motion-plugin" / "app"
+MANIFEST = PLUGIN / "src" / "main" / "AndroidManifest.xml"
+STRINGS = PLUGIN / "src" / "main" / "res" / "values" / "strings.xml"
+GRADLE = PLUGIN / "build.gradle.kts"
+API_DIR = PLUGIN / "src" / "main"
+
+ANDROID = "http://schemas.android.com/apk/res/android"
+DISCOVERY_ACTION = "tv.projectivy.plugin.WALLPAPER_PROVIDER"
+API_PACKAGE = "tv.projectivy.plugin.wallpaperprovider.api"
+
+# Meta-data Projectivy reads off the <service>. apiVersion/uuid/name are what
+# gate the plugin appearing in the list at all.
+REQUIRED_META = {
+    "apiVersion",
+    "uuid",
+    "name",
+    "settingsActivity",
+    "itemsCacheDurationMillis",
+    "updateMode",
+}
+
+# sha256 of the API files as vendored from
+# spocky/projectivy-plugin-wallpaper-provider @ main. Regenerate deliberately
+# (and only when upstream actually changes) with --update-hashes.
+UPSTREAM_SHA256 = {
+    "aidl/tv/projectivy/plugin/wallpaperprovider/api/Event.aidl":
+        "7408317c4f26dddc2c73eab4f5d9002d4d873b02dd26ab0140fbddfcfc945d91",
+    "aidl/tv/projectivy/plugin/wallpaperprovider/api/Wallpaper.aidl":
+        "58349bad403e525eeda0783b551a1673decf78aabdd9c1be61b1666acc07337d",
+    "aidl/tv/projectivy/plugin/wallpaperprovider/api/IWallpaperProviderService.aidl":
+        "f3344411bebe848bc0d7aefcc497ca46d0f3216ac049c6fe3378fdf180bfce65",
+    "java/tv/projectivy/plugin/wallpaperprovider/api/Event.kt":
+        "78c2cae1c5376a4dec9ee611717ffbe7419c3adb5180221fce50c6d846997589",
+    "java/tv/projectivy/plugin/wallpaperprovider/api/Wallpaper.kt":
+        "e9e250330874dcf13ba2810843362e0155fe773e8246e59f2adcf09b7698a2e6",
+    "java/tv/projectivy/plugin/wallpaperprovider/api/WallpaperProviderContract.kt":
+        "272d7faea65ce3b889c0158a59bd4b334965d844ade142af8ab69b3a213f0f03",
+}
+
+errors: list[str] = []
+warnings: list[str] = []
+oks: list[str] = []
+
+
+def err(msg: str) -> None:
+    errors.append(msg)
+
+
+def warn(msg: str) -> None:
+    warnings.append(msg)
+
+
+def ok(msg: str) -> None:
+    oks.append(msg)
+
+
+def a(elem: ET.Element, name: str) -> str | None:
+    return elem.get(f"{{{ANDROID}}}{name}")
+
+
+def check_manifest() -> None:
+    if not MANIFEST.exists():
+        err(f"manifest not found: {MANIFEST.relative_to(ROOT)}")
+        return
+
+    tree = ET.parse(MANIFEST)
+    root = tree.getroot()
+    app = root.find("application")
+    if app is None:
+        err("manifest has no <application>")
+        return
+
+    # --- the provider service -------------------------------------------------
+    services = app.findall("service")
+    provider = None
+    for svc in services:
+        for f in svc.findall("intent-filter"):
+            if any(a(act, "name") == DISCOVERY_ACTION for act in f.findall("action")):
+                provider = svc
+                break
+        if provider is not None:
+            break
+
+    if provider is None:
+        err(
+            f"no <service> declares <action android:name=\"{DISCOVERY_ACTION}\"/>. "
+            "Projectivy discovers plugins solely through this action — without it "
+            "the plugin is invisible."
+        )
+        return
+    ok(f"discovery intent action present on {a(provider, 'name')}")
+
+    if a(provider, "exported") != "true":
+        err("provider service is not android:exported=\"true\" — Projectivy cannot bind to it")
+    else:
+        ok("provider service is exported")
+
+    if a(provider, "enabled") == "false":
+        err("provider service is android:enabled=\"false\"")
+
+    # --- service meta-data ----------------------------------------------------
+    meta = {a(m, "name"): a(m, "value") for m in provider.findall("meta-data")}
+    missing = REQUIRED_META - set(meta)
+    if missing:
+        err(f"provider service is missing meta-data: {', '.join(sorted(missing))}")
+    else:
+        ok(f"all {len(REQUIRED_META)} required meta-data keys present on the service")
+
+    # A classic mistake: meta-data on <application> instead of <service>.
+    app_meta = {a(m, "name") for m in app.findall("meta-data")}
+    stray = app_meta & REQUIRED_META
+    if stray:
+        err(
+            f"meta-data {', '.join(sorted(stray))} is on <application>; "
+            "Projectivy only reads meta-data declared on the <service>"
+        )
+
+    if meta.get("apiVersion") != "1":
+        err(f"apiVersion must be \"1\", found {meta.get('apiVersion')!r}")
+    else:
+        ok("apiVersion = 1")
+
+    # --- uuid resolves to a real UUID v4 --------------------------------------
+    raw_uuid = meta.get("uuid", "")
+    resolved = raw_uuid
+    if raw_uuid.startswith("@string/"):
+        resolved = string_res(raw_uuid.removeprefix("@string/")) or ""
+    if not resolved or resolved == "CHANGE_ME":
+        err("plugin uuid is unset or still the template's CHANGE_ME")
+    else:
+        try:
+            parsed = uuidlib.UUID(resolved)
+            if parsed.version != 4:
+                warn(f"plugin uuid is UUID v{parsed.version}; the template asks for v4")
+            ok(f"plugin uuid is a valid UUID v{parsed.version} ({resolved})")
+        except ValueError:
+            err(f"plugin uuid is not a valid UUID: {resolved!r}")
+
+    # --- settingsActivity actually exists -------------------------------------
+    settings = meta.get("settingsActivity", "")
+    activities = {a(act, "name") for act in app.findall("activity")}
+    if settings and settings not in activities:
+        err(
+            f"settingsActivity {settings!r} is not declared as an <activity> "
+            f"(declared: {', '.join(sorted(x for x in activities if x))})"
+        )
+    elif settings:
+        ok(f"settingsActivity {settings} is declared")
+
+    # --- updateMode is a sane bitmask ----------------------------------------
+    mode = meta.get("updateMode", "")
+    if mode.isdigit():
+        m = int(mode)
+        if not (1 <= m <= 31):
+            err(f"updateMode {m} is outside the valid 1..31 bitmask range")
+        else:
+            ok(f"updateMode = {m}")
+    elif mode and not mode.startswith("@"):
+        err(f"updateMode {mode!r} is not an integer")
+
+    # --- leanback must not hard-gate installation -----------------------------
+    for feat in root.findall("uses-feature"):
+        if a(feat, "name") == "android.software.leanback":
+            if a(feat, "required") == "true":
+                err(
+                    "android.software.leanback is required=\"true\" — this blocks "
+                    "installation on Google TV / Fire TV builds that don't report "
+                    "the flag, which looks identical to 'Projectivy can't see it'. "
+                    "Set required=\"false\"."
+                )
+            else:
+                ok("android.software.leanback is required=false (installs everywhere)")
+
+    if not any(
+        a(p, "name") == "android.permission.INTERNET"
+        for p in root.findall("uses-permission")
+    ):
+        warn("no INTERNET permission — the remote feed will always come back empty")
+
+
+def string_res(name: str) -> str | None:
+    if not STRINGS.exists():
+        return None
+    for s in ET.parse(STRINGS).getroot().findall("string"):
+        if s.get("name") == name:
+            return (s.text or "").strip()
+    return None
+
+
+def check_gradle() -> None:
+    if not GRADLE.exists():
+        err("motion-plugin/app/build.gradle.kts not found")
+        return
+    text = GRADLE.read_text()
+
+    if not re.search(r"aidl\s*=\s*true", text):
+        err(
+            "buildFeatures { aidl = true } is missing — AGP 8+ does not compile "
+            "AIDL by default, so IWallpaperProviderService.Stub never gets generated"
+        )
+    else:
+        ok("AIDL compilation is enabled")
+
+    if "parcelize" not in text:
+        err("the kotlin-parcelize plugin is not applied — @Parcelize Wallpaper/Event won't marshal")
+    else:
+        ok("kotlin-parcelize is applied")
+
+    # R8 will happily strip an exported service that nothing in-app references.
+    minify = re.search(r"isMinifyEnabled\s*=\s*(\w+)", text)
+    if minify and minify.group(1) == "true":
+        proguard = PLUGIN / "proguard-rules.pro"
+        rules = proguard.read_text() if proguard.exists() else ""
+        if API_PACKAGE not in rules:
+            err(
+                "minify is on but proguard-rules.pro does not keep "
+                f"{API_PACKAGE}.** — R8 will rename the AIDL stub and break the bind"
+            )
+
+    m = re.search(r'versionName\s*=\s*"([^"]+)"', text)
+    if m:
+        ok(f"plugin versionName = {m.group(1)}")
+
+
+def check_api_parity() -> None:
+    """The vendored API must stay byte-identical to upstream.
+
+    The AIDL interface descriptor is derived from the package + interface name,
+    and the parcelable field order is part of the wire format. Any edit here
+    produces a plugin that binds and then fails every transaction.
+    """
+    for rel, expected in UPSTREAM_SHA256.items():
+        path = API_DIR / rel
+        if not path.exists():
+            err(f"vendored API file missing: {rel}")
+            continue
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        if expected and digest != expected:
+            err(
+                f"{rel} has drifted from Spocky's upstream API "
+                f"(sha256 {digest[:12]}… != {expected[:12]}…). "
+                "This API is frozen — reverting is the fix."
+            )
+        elif expected:
+            ok(f"{rel} matches upstream")
+
+    # Package relocation is the single most common way people break discovery.
+    for rel in UPSTREAM_SHA256:
+        path = API_DIR / rel
+        if not path.exists():
+            continue
+        head = path.read_text(errors="replace")[:400]
+        if f"package {API_PACKAGE}" not in head:
+            err(
+                f"{rel} is not in package {API_PACKAGE}. The API package name is "
+                "part of the AIDL descriptor and must never be relocated."
+            )
+
+
+def update_hashes() -> int:
+    lines = []
+    for rel in UPSTREAM_SHA256:
+        path = API_DIR / rel
+        digest = hashlib.sha256(path.read_bytes()).hexdigest() if path.exists() else None
+        lines.append(f'    "{rel}": {digest!r},')
+    print("UPSTREAM_SHA256 = {")
+    print("\n".join(lines))
+    print("}")
+    return 0
+
+
+def main() -> int:
+    if "--update-hashes" in sys.argv:
+        return update_hashes()
+
+    check_manifest()
+    check_gradle()
+    check_api_parity()
+
+    for line in oks:
+        print(f"  ok   {line}")
+    for line in warnings:
+        print(f"  warn {line}")
+    for line in errors:
+        print(f"  FAIL {line}")
+
+    print()
+    print(f"{len(oks)} passed, {len(warnings)} warnings, {len(errors)} failures")
+    if errors:
+        print("\nCore Motion would NOT be reliably detected by Projectivy.")
+        return 1
+    print("Core Motion satisfies Projectivy's discovery contract.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why this exists

Three features that together close the Core Motion detection gap and ship the first buildable plugin.

### 1. In-app update checker (Core Shift)

Core Shift had no way to notify users when a new version was available. Added the same update-checker pattern the icon pack uses — polls a version manifest on launch, offers one-tap install via FileProvider.

### 2. Core Motion detection fix

**Root cause: Core Motion was never built.** No workflow referenced `motion-plugin/`, and no release ever contained a Core Motion APK — so there was never anything installed for Projectivy to detect. The plugin source was always correct (AIDL byte-identical to upstream, sha256 verified).

- `.github/workflows/core-motion-apk.yml` — builds/signs/publishes `coremotion-release.apk` on `motion-v*` tags + floating `motion` tag; asserts via `aapt2` that the built APK exposes the discovery surface
- `leanback required=true` → `false` (was blocking install on some TV builds)
- `MotionFeed` — 20s+20s blocking binder-thread fetch → 6s/8s, 15-min cache, last-good fallback
- `Diagnostics.kt` + settings panel — runs Projectivy's own `queryIntentServices` on-device
- `tools/verify_motion_plugin.py` — 17 offline contract checks, all passing (CI-wired)

### 3. Monet Launcher route (Aerial Views bridge)

Monet has no plugin API (closed source). The viable route is the Aerial Views bridge:
`Motion/aerial-entries.json` → Aerial Views (custom feed) → Monet Launcher

- `tools/build_aerial_feed.py` projects `Motion/live-feed.json` into Aerial Views format; CI enforces sync
- `docs/MONET_LAUNCHER.md` documents why no Monet plugin is possible and the routes that work

### 4. Core Shift list motion

Suite-palette list animations drawn from the wallpaper collection's colour ramp:
- `CoreSpectrum.kt` — shared phase source (Cyan → Glow → Build Blue → Dusk Violet → Ember)
- `RowMotion.kt` — focus-driven card lift, travelling border, spine wipe, thumb saturation/ken-burns
- Staggered rise entry animation; payload binds for status (no more teardown of focused row)
- `.gitignore` fixed (was root-anchored; building subprojects staged ~1200 class files)

## Files changed

**Update checker (8 files):**
- `Latestrelease/shift-version.json`, `UpdateChecker.kt`, `UpdateInstaller.kt`, `file_paths.xml`
- `AndroidManifest.xml`, `MainActivity.kt`, `activity_main.xml`, `strings.xml`

**Core Motion detection (12 files):**
- `.github/workflows/core-motion-apk.yml` (new), `motion-plugin/` changes (manifest, build.gradle, MotionFeed, SettingsFragment, WallpaperProviderService, Diagnostics, strings)
- `tools/verify_motion_plugin.py` (new), `docs/PROJECTIVY_DETECTION.md` (new)

**Monet route (5 files):**
- `Motion/aerial-entries.json` (new), `tools/build_aerial_feed.py` (new)
- `docs/MONET_LAUNCHER.md` (new), `.gitignore`, `README.md`

**List motion (8 files):**
- `CoreSpectrum.kt`, `RowMotion.kt`, `LiveAdapter.kt`, `MainActivity.kt`
- `activity_main.xml`, `item_live.xml`, `card_bg.xml`, `colors.xml`
- `shift/app/src/main/res/anim/` (2 new animation resources)
- `docs/shift-list-motion-preview.html` (new)

## Verification

- [x] 17/17 contract checks pass (`tools/verify_motion_plugin.py`)
- [x] Aerial feed in sync — 10 assets match `Motion/live-feed.json`
- [x] Vendored AIDL/parcelables byte-identical to Spocky's upstream (sha256)
- [x] Update checker mirrors proven icon pack pattern
- [ ] No Android SDK in this environment — APK builds not attempted
- [ ] CI workflow has never executed (new)
- [ ] No device testing — Projectivy bind and `getWallpapers()` round-trip unverified
- [ ] Monet + Aerial Views integration untested end-to-end