### PR TITLE
chore(shift): bump to v2.1.0 (versionCode 4)

### DIFF
--- a/Latestrelease/shift-version.json
+++ b/Latestrelease/shift-version.json
@@ -1,6 +1,6 @@
 {
-  "versionCode": 3,
-  "versionName": "2.0.1",
+  "versionCode": 4,
+  "versionName": "2.1.0",
   "releaseDate": "2026-08-23",
   "apkUrl": "https://github.com/brevityA/CoreBuildsApps/releases/download/shift/coreshift-release.apk",
   "releaseNotesUrl": "https://github.com/brevityA/CoreBuildsApps/releases",

--- a/shift/app/build.gradle.kts
+++ b/shift/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
         applicationId = "dev.corebuilds.shift"
         minSdk = 26
         targetSdk = 34
-        versionCode = 3
-        versionName = "2.0.1"
+        versionCode = 4
+        versionName = "2.1.0"
     }
 
     signingConfigs {


### PR DESCRIPTION
## Why this exists

v2.0.1 was never tagged. Current `main` now includes the D-pad fix, in-app update checker, suite-palette list motion, and Core Motion detection fix — feature additions that warrant a minor bump rather than a patch.

## What changed

- `shift/app/build.gradle.kts` — `versionCode` 3→4, `versionName` "2.0.1"→"2.1.0"
- `Latestrelease/shift-version.json` — updated to match

## After merge

Tag locally to trigger the CI release build:
```bash
git tag shift-v2.1.0
git push origin shift-v2.1.0
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJbpQkj9fcYQq4sLMHkjVQ)_