### PR TITLE
fix(shift): library visibility, D-pad navigation and download reachability

### DIFF
--- a/Latestrelease/shift-version.json
+++ b/Latestrelease/shift-version.json
@@ -1,6 +1,6 @@
 {
-  "versionCode": 7,
-  "versionName": "2.3.1",
+  "versionCode": 8,
+  "versionName": "2.3.2",
   "releaseDate": "2026-08-23",
   "apkUrl": "https://github.com/brevityA/CoreBuildsApps/releases/download/shift/coreshift-release.apk",
   "releaseNotesUrl": "https://github.com/brevityA/CoreBuildsApps/releases",

--- a/shift/README.md
+++ b/shift/README.md
@@ -44,7 +44,7 @@ AIOStreams paths and is not used as an arbitrary wallpaper relay.
 cd shift && ./gradlew :app:assembleDebug    # JDK 17 + Android SDK
 ```
 
-Standalone Gradle root, package `dev.corebuilds.shift`, version 2.2.0 (versionCode 5),
+Standalone Gradle root, package `dev.corebuilds.shift`, version 2.3.2 (versionCode 8),
 minSdk 26, target/compile 34, AGP 8.5.2 / Kotlin 1.9.24. Dependencies: appcompat,
 core-ktx, recyclerview.
 No WorkManager or background service is used; network refreshes happen only

--- a/shift/app/build.gradle.kts
+++ b/shift/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
         applicationId = "dev.corebuilds.shift"
         minSdk = 26
         targetSdk = 34
-        versionCode = 7
-        versionName = "2.3.1"
+        versionCode = 8
+        versionName = "2.3.2"
     }
 
     signingConfigs {

--- a/shift/app/build.gradle.kts
+++ b/shift/app/build.gradle.kts
@@ -30,6 +30,7 @@ android {
     buildTypes {
         release {
             isMinifyEnabled = false
+            isShrinkResources = false
             val ks = System.getenv("KEYSTORE_PATH")
             if (ks != null && file(ks).exists()) {
                 signingConfig = signingConfigs.getByName("release")

--- a/shift/app/src/main/java/dev/corebuilds/shift/MainActivity.kt
+++ b/shift/app/src/main/java/dev/corebuilds/shift/MainActivity.kt
@@ -57,6 +57,8 @@ class MainActivity : AppCompatActivity() {
     private var spectrum: ValueAnimator? = null
     private var contentRefreshing = false
     private var currentEntries: List<LiveEntry> = emptyList()
+    private var focusRunnable: Runnable? = null
+    private var focusRetries = 0
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -225,6 +227,7 @@ class MainActivity : AppCompatActivity() {
                 currentEntries = result.entries
                 adapter.submit(result.entries)
                 updateEmptyState(result.entries)
+                if (result.entries.isNotEmpty()) requestInitialFocus()
                 result.entries.firstOrNull { it.scene != null }?.let { selectStage(it) }
 
                 when {
@@ -342,16 +345,29 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun requestInitialFocus() {
-        list.post(object : Runnable {
+        cancelFocusRunnable()
+        focusRetries = 0
+        val runnable = object : Runnable {
             override fun run() {
                 val holder = list.findViewHolderForAdapterPosition(0)
                 if (holder != null) {
                     holder.itemView.findViewById<Button>(R.id.btn_preview)?.requestFocus()
-                } else if (adapter.itemCount > 0) {
+                    focusRunnable = null
+                } else if (adapter.itemCount > 0 && focusRetries < MAX_FOCUS_RETRIES) {
+                    focusRetries++
                     list.post(this)
+                } else {
+                    focusRunnable = null
                 }
             }
-        })
+        }
+        focusRunnable = runnable
+        list.post(runnable)
+    }
+
+    private fun cancelFocusRunnable() {
+        focusRunnable?.let { list.removeCallbacks(it) }
+        focusRunnable = null
     }
 
     private fun restoreLibraryFocus() {
@@ -416,6 +432,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     override fun onDestroy() {
+        cancelFocusRunnable()
         spectrum?.cancel()
         spectrum = null
         io.shutdown()
@@ -424,5 +441,6 @@ class MainActivity : AppCompatActivity() {
 
     companion object {
         private const val REQ_WRITE = 102
+        private const val MAX_FOCUS_RETRIES = 10
     }
 }

--- a/shift/app/src/main/java/dev/corebuilds/shift/MainActivity.kt
+++ b/shift/app/src/main/java/dev/corebuilds/shift/MainActivity.kt
@@ -122,6 +122,7 @@ class MainActivity : AppCompatActivity() {
         list.adapter = adapter
         list.scheduleLayoutAnimation()
         updateEmptyState(currentEntries)
+        requestInitialFocus()
 
         val firstPrequel = currentEntries.firstOrNull { it.scene != null }
         if (firstPrequel != null) {
@@ -130,8 +131,6 @@ class MainActivity : AppCompatActivity() {
         }
         contentButton.setOnClickListener { refreshContent() }
 
-        // The stage is a real animated procedural preview, not a static poster.
-        // The production MP4 feed still refreshes independently in the background.
         refreshContent()
         checkForUpdate()
     }
@@ -338,6 +337,28 @@ class MainActivity : AppCompatActivity() {
         if (updateFile.exists() && UpdateInstaller.canInstall(this) && !installOffered) {
             installOffered = true
             UpdateInstaller.install(this, updateFile)
+        }
+        restoreLibraryFocus()
+    }
+
+    private fun requestInitialFocus() {
+        list.post(object : Runnable {
+            override fun run() {
+                val holder = list.findViewHolderForAdapterPosition(0)
+                if (holder != null) {
+                    holder.itemView.findViewById<Button>(R.id.btn_preview)?.requestFocus()
+                } else if (adapter.itemCount > 0) {
+                    list.post(this)
+                }
+            }
+        })
+    }
+
+    private fun restoreLibraryFocus() {
+        if (list.hasFocus() || currentEntries.isEmpty()) return
+        val focused = currentFocus
+        if (focused == null || focused == window.decorView.rootView) {
+            requestInitialFocus()
         }
     }
 

--- a/shift/app/src/main/res/layout/activity_main.xml
+++ b/shift/app/src/main/res/layout/activity_main.xml
@@ -76,7 +76,7 @@
     <FrameLayout
         android:id="@+id/stage_card"
         android:layout_width="match_parent"
-        android:layout_height="190dp"
+        android:layout_height="150dp"
         android:layout_marginBottom="10dp"
         android:background="@drawable/procedural_overlay"
         android:clipChildren="true">
@@ -154,7 +154,8 @@
             android:textColor="@color/btn_text"
             android:textSize="11sp"
             android:background="@drawable/btn_bg"
-            android:focusable="true" />
+            android:focusable="true"
+            android:nextFocusDown="@id/quality_1080" />
 
         <Button
             android:id="@+id/speed_normal"
@@ -166,7 +167,8 @@
             android:textColor="@color/btn_text"
             android:textSize="11sp"
             android:background="@drawable/btn_bg"
-            android:focusable="true" />
+            android:focusable="true"
+            android:nextFocusDown="@id/quality_1080" />
 
         <Button
             android:id="@+id/speed_fast"
@@ -178,7 +180,8 @@
             android:textColor="@color/btn_text"
             android:textSize="11sp"
             android:background="@drawable/btn_bg"
-            android:focusable="true" />
+            android:focusable="true"
+            android:nextFocusDown="@id/quality_1080" />
 
         <TextView
             android:layout_width="wrap_content"
@@ -199,7 +202,8 @@
             android:textColor="@color/btn_text"
             android:textSize="11sp"
             android:background="@drawable/btn_bg"
-            android:focusable="true" />
+            android:focusable="true"
+            android:nextFocusDown="@id/quality_1080" />
 
         <Button
             android:id="@+id/length_20"
@@ -211,7 +215,8 @@
             android:textColor="@color/btn_text"
             android:textSize="11sp"
             android:background="@drawable/btn_bg"
-            android:focusable="true" />
+            android:focusable="true"
+            android:nextFocusDown="@id/quality_1080" />
 
         <Button
             android:id="@+id/length_30"
@@ -223,7 +228,8 @@
             android:textColor="@color/btn_text"
             android:textSize="11sp"
             android:background="@drawable/btn_bg"
-            android:focusable="true" />
+            android:focusable="true"
+            android:nextFocusDown="@id/quality_1080" />
     </LinearLayout>
 
     <LinearLayout
@@ -252,7 +258,8 @@
             android:textColor="@color/btn_text"
             android:textSize="12sp"
             android:background="@drawable/btn_bg"
-            android:focusable="true" />
+            android:focusable="true"
+            android:nextFocusDown="@id/content_btn" />
 
         <Button
             android:id="@+id/quality_4k"
@@ -264,7 +271,8 @@
             android:textColor="@color/btn_text"
             android:textSize="12sp"
             android:background="@drawable/btn_bg"
-            android:focusable="true" />
+            android:focusable="true"
+            android:nextFocusDown="@id/content_btn" />
 
         <TextView
             android:id="@+id/quality_status"
@@ -335,18 +343,36 @@
             android:textSize="12sp"
             android:textColor="@color/btn_text"
             android:background="@drawable/btn_bg"
-            android:focusable="true" />
+            android:focusable="true"
+            android:nextFocusDown="@id/live_list" />
     </LinearLayout>
 
-    <TextView
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="3dp"
         android:layout_marginBottom="5dp"
-        android:fontFamily="monospace"
-        android:text="@string/library_label"
-        android:textColor="@color/cb_text_secondary"
-        android:textSize="11sp" />
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:fontFamily="monospace"
+            android:text="@string/library_label"
+            android:textColor="@color/cb_text_secondary"
+            android:textSize="11sp" />
+
+        <TextView
+            android:id="@+id/nav_hint"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:fontFamily="monospace"
+            android:text="@string/nav_hint"
+            android:textColor="@color/cb_text_secondary"
+            android:textSize="10sp" />
+    </LinearLayout>
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/live_list"
@@ -357,7 +383,9 @@
         android:clipChildren="false"
         android:paddingStart="6dp"
         android:paddingEnd="6dp"
-        android:paddingBottom="24dp" />
+        android:paddingBottom="24dp"
+        android:descendantFocusability="afterDescendants"
+        android:nextFocusUp="@id/content_btn" />
 
     <TextView
         android:id="@+id/empty"

--- a/shift/app/src/main/res/layout/activity_main.xml
+++ b/shift/app/src/main/res/layout/activity_main.xml
@@ -384,6 +384,8 @@
         android:paddingStart="6dp"
         android:paddingEnd="6dp"
         android:paddingBottom="24dp"
+        android:focusable="true"
+        android:focusableInTouchMode="true"
         android:descendantFocusability="afterDescendants"
         android:nextFocusUp="@id/content_btn" />
 

--- a/shift/app/src/main/res/values/strings.xml
+++ b/shift/app/src/main/res/values/strings.xml
@@ -54,4 +54,6 @@
     <string name="content_checking">Checking for Core Motion updates…</string>
     <string name="content_refresh">Refresh</string>
     <string name="content_refreshing">Refreshing…</string>
+
+    <string name="nav_hint">↑↓ browse · OK select</string>
 </resources>

--- a/tests/test_core_shift_content.py
+++ b/tests/test_core_shift_content.py
@@ -28,11 +28,11 @@ def test_remote_content_is_separate_from_apk_update():
     assert "UpdateChecker.check" in activity
     assert "networkSucceeded" in remote
     gradle = (ROOT / "shift/app/build.gradle.kts").read_text()
-    assert 'versionName = "2.3.1"' in gradle
-    assert 'versionCode = 7' in gradle
+    assert 'versionName = "2.3.2"' in gradle
+    assert 'versionCode = 8' in gradle
     update = (ROOT / "Latestrelease/shift-version.json").read_text()
-    assert '"versionName": "2.3.1"' in update
-    assert '"versionCode": 7' in update
+    assert '"versionName": "2.3.2"' in update
+    assert '"versionCode": 8' in update
     assert "content_banner" in (SHIFT / "res/layout/activity_main.xml").read_text()
     assert "motion-prequels/prequel-feed.json" in remote
 


### PR DESCRIPTION
## Why this exists

Core Shift 2.3.1 consumed nearly the entire TV viewport with the hero stage and controls before the library began. On a real Android TV / Fire TV, the user could not reach library rows or Download buttons via D-pad navigation — the focus path never explicitly entered the RecyclerView from the controls above it.

## Summary

- **Layout**: reduce hero stage from 190dp to 150dp so library rows are visible without scrolling past blank space
- **D-pad focus paths**: explicit `nextFocusDown` from speed/length controls → quality selector → content refresh → library RecyclerView, and `nextFocusUp` from list back to content refresh
- **RecyclerView focus group**: `descendantFocusability="afterDescendants"` so D-pad enters the list and reaches Preview/Download buttons
- **Initial focus**: after adapter attach, focus lands on the first library item's Preview button (safe post-layout retry waits for the first ViewHolder)
- **Focus restoration**: returning from ProceduralPreviewActivity restores library focus instead of losing it to an off-screen control
- **Navigation hint**: "↑↓ browse · OK select" label beside the library header
- **Version bump**: 2.3.2 (versionCode 8) in build.gradle.kts, shift-version.json, and README

## Download behaviour (verified by code review)

The download path is already correctly wired:
- `LiveAdapter` checks `item.hasTier(quality)` and `item.mediaAvailable` — disables Download with "Preview only" for seeds, "X unavailable" for missing tiers
- `LiveDownloader.download()` calls `entry.urlFor(quality)` → 1080p uses `url1080p`, 4K uses `url4k`
- Prequel seeds have `mediaAvailable = false`; remote feed entries override with `mediaAvailable = true`
- `merge()` replaces seed entries when production media arrives

## Files changed (7)

| File | Change |
|---|---|
| `shift/app/src/main/res/layout/activity_main.xml` | Stage height, focus paths, nav hint, RecyclerView focus group |
| `shift/app/src/main/java/dev/corebuilds/shift/MainActivity.kt` | `requestInitialFocus()`, `restoreLibraryFocus()` |
| `shift/app/src/main/res/values/strings.xml` | `nav_hint` string |
| `shift/app/build.gradle.kts` | versionCode 8, versionName 2.3.2 |
| `Latestrelease/shift-version.json` | Match 2.3.2 |
| `shift/README.md` | Version line updated |
| `tests/test_core_shift_content.py` | Version assertions bumped |

## Verification

```
python -m pytest -q tests/test_core_shift_content.py
7 passed in 0.06s
```

XML validated (`xml.etree.ElementTree.parse` — both `activity_main.xml` and `strings.xml`).

No Android SDK in this environment — the APK has not been locally built. Device verification (D-pad focus paths, Download reachability, initial focus) requires a real Android TV or Fire TV.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJbpQkj9fcYQq4sLMHkjVQ)_