### PR TITLE
feat(ticker): Core Line v1.2.0 — updates, overlay, TV polish

### DIFF
--- a/ticker/AUDIT.md
+++ b/ticker/AUDIT.md
@@ -147,9 +147,9 @@ Legend — **P0** blank/crash · **P1** degraded/self-healing gap · **P2** poli
 
 See `VERIFICATION.md` for full detail. Summary:
 
-- **Tests:** 77/77 pass (`npm test`) — 24 baseline + backoff, source-registry, parser-robustness, client-slate-resilience, ticker, watchdog, and feedback suites.
+- **Tests:** 88/88 pass (`npm test`) — 24 baseline + backoff, source-registry, parser-robustness, client-slate-resilience, ticker, watchdog, feedback, watch, and version suites.
 - **Failure injection:** dead-feed isolation, last-good retention, backoff skip, malformed/empty/garbage bodies, real-socket 502 route — all verified without a single blank slate.
 - **Soak:** 3,000-cycle (~50 h) in-process soak — 0 blank, 7.11 MB heap growth; 70-cycle real-socket server soak — 70/70 responses, 0 kB VmRSS growth.
 - **Browser smoke (headless Chromium):** drawer hidden on first paint (A3 fixed), ribbon moving, fonts loaded, 0 console errors.
-- **Release build:** `releases/CoreLine-debug-v1.0.2.apk` and `CoreLine-release-unsigned-v1.0.2.apk` built with JDK 21 + SDK 34; manifest/leanback/asset contents verified. Clean-install on a device/emulator remains [USER TO SUPPLY].
+- **Release build:** `releases/CoreLine-debug-v1.2.0.apk` and `CoreLine-release-unsigned-v1.2.0.apk` built with JDK 21 + SDK 34; manifest/leanback/FileProvider/asset contents verified (versionCode 5). Clean-install on a device/emulator remains [USER TO SUPPLY].
 - **Correction:** `fonts/outfit-var.woff2` is a real variable font (fontTools: `fvar`, wght 100–900) — F4 was a false alarm.

--- a/ticker/CLAUDE_HANDOVER.md
+++ b/ticker/CLAUDE_HANDOVER.md
@@ -34,7 +34,7 @@ Node 20+, zero npm runtime deps. The rest of the repo is unrelated.
 | 1 Never blank | backoff, per-source last-good, parser hardening, isolation | ✅ done, tested |
 | 2 Broadcast polish | constant px/s ribbon, watchdog, bundled fonts, TV scale, overscan | ✅ done, tested |
 | 3 D-pad / settings | focus trap, reorder, refresh interval, speed/position | ✅ done, tested |
-| 4 Tests + verification + build | 77/77 tests, soaks, failure injection, 2 APKs | ✅ done (see §9) |
+| 4 Tests + verification + build | 88/88 tests, soaks, failure injection, 2 APKs | ✅ done (see §9) |
 
 **Only one thing is still outside the sandbox:** clean-install + first-run on a
 real device/emulator and the multi-hour device soak. That is **[USER TO SUPPLY]**
@@ -48,7 +48,59 @@ real device/emulator and the multi-hour device soak. That is **[USER TO SUPPLY]*
 (`content_html`/`date_published`); (5) sport super-tabs (`SPORT_GROUPS`); (6)
 favorites on TV (card ★ button + settings team checklist); (7) `[data-tv]` 10-foot
 pass (root 20px, minmax(360px,1fr) grid, 5px focus ring, header stats hidden).
-77/77 tests.
+
+**2026-09-04 second round — D-pad, settings, watch apps** (see `VERIFICATION.md` §8.2):
+(8) rewritten spatial D-pad nav (`tv.js`) — cross-axis overlap preference
+("down means down", not diagonal), auto-scroll focused item into view, focus never
+dies; (9) settings menu restructured into a **left rail + content pane** (the
+standard TV pattern — Netflix/Leanback style), with Feeds / Scoreboards /
+Ticker & display / Watch apps / Help sections; (10) **Watch apps** — assign any
+installed app per league, then ▶ Watch on a game (or the W key) opens it;
+web fallback opens the ESPN game page. Android side: `LineBridge.listLaunchableApps()`
+/ `openApp()` / `openUrl()` + manifest `<queries>` (MAIN/LAUNCHER +
+LEANBACK_LAUNCHER, no QUERY_ALL_PACKAGES). 88/88 tests.
+
+**2026-09-04 third round — in-app updates + full UI polish** (see `VERIFICATION.md` §8.3):
+(11) **in-app updates** (sideload, no Play Store) — `lib/version.mjs` (semver
+compare + GitHub-release parse/status, unit-tested), an **Updates** settings
+pane (current version, update banner, release notes, check/download/install
+buttons), and an Android updater (`UpdateManager.kt`): download the
+`coreline-release.apk` through a host-allowlisted URL (github.com /
+*.github.com / release-assets.githubusercontent.com), write to `cache/updates/`,
+then `ACTION_VIEW` via a scoped FileProvider (`file_paths.xml` exposes only
+`cache/updates/`). `REQUEST_INSTALL_PACKAGES` declared so the system installer
+can prompt for unknown-sources. `MainActivity.getVersion()` /
+`installUpdate(url)` + `LineBridge` bindings; `BuildConfig.VERSION_NAME` feeds
+the comparison. (12) **UI polish pass** — tactile button states, focus rings,
+input accent colours, broadcast-style section labels, chyron edge fades, thin
+scrollbars, tabular numerals, card/toggle shadows, reduced-motion support.
+Local version bumped to **versionCode 5 / versionName 1.2.0** (ahead of
+GitHub's 1.1.0). 88/88 tests.
+
+**2026-09-04 fourth round — phone floating overlay** (see `VERIFICATION.md` §8.4):
+(13) **ticker over other apps on phones/tablets** — `OverlayService.kt` draws
+the chyron as a translucent, touch-through, always-on-top window above every
+other app (foreground service, `TYPE_APPLICATION_OVERLAY`). It reuses the SAME
+web app (`https://coreline.local/index.html?native=1&overlay=1`) so it shares
+the parser, the `/api/proxy` data path, and the app's localStorage settings;
+the overlay page strips everything but the chyron via `[data-overlay]` CSS.
+Toggle lives in Settings → Ticker & display (phone/native only). Needs
+`SYSTEM_ALERT_WINDOW` (Settings → display over other apps); on Android TV the
+app refuses to start it (TV has no overlay windows). Stop via the notification
+or the checkbox. `MainActivity`/`LineBridge` add `canDrawOverlays` /
+`overlayActive` / `startOverlay` / `stopOverlay`.
+
+**2026-09-04 fifth round — Android TV UI consistency** (see `VERIFICATION.md` §8.5):
+(14) the TV (10-foot) pass was **inconsistent and blown out** — text sizes
+scattered from 13.2px (health pill, `.when`) to 68px (hero score), checkboxes
+(16px) smaller than their labels, square controls at 44/46/52/56px. Replaced
+the ad-hoc `[data-tv]` overrides in `public/css/app.css` with ONE coherent
+scale ladder on the 20px root — micro .8rem / body .95rem / control 1.1rem /
+title 1.3rem / display 2rem; every square control 56px (48px in-card); hero
+numerals tamed to 48/56px; checkboxes 26px (and `flex: 0 0 auto` so they can't
+shrink); `.abbr` gets an ellipsis guard. Pinned by headless TV checks in
+`tests/smoke-updates.mjs` (health ≥16px, team names == brand size, no abbr
+overflow). Phone layout untouched.
 
 ---
 
@@ -86,16 +138,22 @@ sources. It is a TV *guide*; the user pastes their own RSS.
 | Path | What it is |
 |---|---|
 | `AUDIT.md` | Phase 0 audit — authoritative findings A1–F7 + fix→requirement map + verification status (§5 of that file) |
-| `VERIFICATION.md` | Phase 4 report: 77/77 tests, failure injection, soaks, browser smoke, APK build + manifest checks, manual/soak checklist, and the 2026-09-04 supporter-feedback round (§8–8.1) |
+| `VERIFICATION.md` | Phase 4 report: 88/88 tests, failure injection, soaks, browser smoke, APK build + manifest checks, manual/soak checklist, and the 2026-09-04 supporter-feedback + D-pad/settings/watch-apps + updates/polish + overlay + TV-consistency rounds (§8–8.5) |
 | `lib/backoff.mjs` | `createBackoff()` — exp backoff + jitter, cap, `Retry-After` parser. Shared (server + client). |
 | `lib/source-registry.mjs` | `SourceRegistry` — per-league (`league:id`) and per-feed (`feed:url`) keys; backoff state, `lastGood[]`, `lastError`, `health`, hydrate/dehydrate; `MAX_ITEMS_PER_SOURCE = 100`. |
+| `lib/watch.mjs` | Watch integration: curated sports-app list, `sortAppsForPicker`, `espnWebUrl`, `watchChoiceFor`, `leagueIdForLabel` — pure logic for "open a game in an assigned app". |
+| `lib/version.mjs` | In-app update logic: `compareVersions`, `versionFromCorelineTag`, `latestCorelineRelease`, `updateStatus` — pure, unit-tested. |
+| `android/app/src/main/java/dev/corebuilds/line/UpdateManager.kt` | Sideload updater: host-allowlisted download → `cache/updates/` → FileProvider `ACTION_VIEW` to the system installer. |
+| `android/app/src/main/res/xml/file_paths.xml` | FileProvider paths — exposes only `cache/updates/`. |
+| `android/app/src/main/java/dev/corebuilds/line/OverlayService.kt` | Phone floating ticker: translucent touch-through `TYPE_APPLICATION_OVERLAY` window hosting the same WebView app (`?native=1&overlay=1`); foreground service w/ stop notification; TV refused. |
+| `android/app/src/main/res/drawable/ic_notification.xml` | Ticker-strip glyph for the overlay foreground-service notification. |
 | `public/js/ticker.js` | `Ticker` class — constant px/s `translate3d` ribbon, rAF loop, seamless wrap, ResizeObserver re-measure. Replaces the CSS-keyframe crawl. |
 | `public/js/watchdog.js` | `startWatchdog()` — samples ribbon progress, fires stall callback, wakes on visibility/page/focus. |
-| `tests/backoff.test.mjs`, `tests/source-registry.test.mjs`, `tests/parser-robustness.test.mjs`, `tests/client-slate-resilience.test.mjs`, `tests/ticker.test.mjs`, `tests/watchdog.test.mjs`, `tests/feedback.test.mjs` | New unit suites (53 of the 77 tests; `feedback.test.mjs` pins the 2026-09-04 supporter complaints) |
+| `tests/backoff.test.mjs`, `tests/source-registry.test.mjs`, `tests/parser-robustness.test.mjs`, `tests/client-slate-resilience.test.mjs`, `tests/ticker.test.mjs`, `tests/watchdog.test.mjs`, `tests/feedback.test.mjs`, `tests/watch.test.mjs`, `tests/version.test.mjs` | New unit suites (64 of the 88 tests; `feedback.test.mjs` pins the supporter complaints, `watch.test.mjs` pins the watch-app URL/assignment logic, `version.test.mjs` pins the in-app update semver/tag/status logic) |
 | `tests/soak.mjs` | Standalone accelerated in-process soak (`node tests/soak.mjs`; not part of `npm test`) |
 | `tests/mockfeeds.mjs` | Hostile fixture server on 127.0.0.1:8799 (`/good` 200 RSS, `/down` 502) for real-socket server soaks |
-| `releases/CoreLine-debug-v1.0.2.apk` | **Installable, debug-signed** sideload APK (1.82 MB) |
-| `releases/CoreLine-release-unsigned-v1.0.2.apk` | Release variant, unsigned (1.29 MB) — sign via CI keystore |
+| `releases/CoreLine-debug-v1.2.0.apk` | **Installable, debug-signed** sideload APK (3.08 MB) |
+| `releases/CoreLine-release-unsigned-v1.2.0.apk` | Release variant, unsigned (2.26 MB) — sign via CI keystore |
 
 ### Modified files
 | Path | Change |
@@ -104,13 +162,15 @@ sources. It is a TV *guide*; the user pastes their own RSS.
 | `lib/parser.mjs` | Exports `MAX_ITEMS_PER_FEED = 100`; RSS/JSON capped; `stripTags` CDATA-safe; JSON `null`/non-object rows skipped |
 | `lib/scoreboard.mjs` | Exports `DEFAULT_LEAGUES` + `LEAGUE_LABELS` (single source for defaults) |
 | `server.mjs` | Uses `createBackoff` + `DEFAULT_LEAGUES`; `/api/rss` and `/api/slate` use `resilientFeed`; per-league scoreboard slots w/ backoff + last-good; slate adds `feeds[].stale` and `health` |
-| `public/js/app.js` | Rewritten wiring: single-flight refresh, silent resume refresh, `prefers-reduced-motion` clamps speed ≤12 px/s, ticker/watchdog integration, health pill |
-| `public/js/state.js` | Rewritten sanitizer/defaults/cache |
-| `public/js/tv.js` | Drawer focus confinement + focus restore |
-| `public/index.html` | Boot guard (old-WebView message), health pill, speed stepper, refresh/position selects, `crawl-mask` id; **no Google Fonts link** |
+| `public/js/app.js` | Rewritten wiring: single-flight refresh, silent resume refresh, `prefers-reduced-motion` clamps speed ≤12 px/s, ticker/watchdog integration, health pill; sport super-tabs, per-feed 📡 tabs, favorites (card ★ + team picker), Watch buttons + `openGame`, drawer rail sections, `W` key; Updates panel (`renderUpdates` / `checkForUpdates` / `installUpdateFlow`) |
+| `public/js/state.js` | Rewritten sanitizer/defaults/cache; adds `watchApps` (leagueId → app pkg or `web`) |
+| `public/js/tv.js` | Spatial D-pad nav: cross-axis overlap preference, scroll-into-view, focus confinement in the drawer |
+| `public/index.html` | Boot guard (old-WebView message), health pill, speed stepper, refresh/position selects, `crawl-mask` id; **no Google Fonts link**; drawer restructured into a rail + 5 sections (Feeds / Scoreboards / Ticker & display / Watch apps / Help) |
 | `public/css/app.css` | Local `@font-face`s, TV/overscan/top-position styles, `.health` states, league-accent cards, JS-transform crawl styling, reduced-motion/TV scaling, stepper/reorder/boot-fallback CSS, and the global fix `[hidden] { display: none; }` (see A3) |
 | `android/.../LineWebClient.kt` | Oversized fetched bodies → HTTP 502 (not silent truncation) |
-| `android/.../MainActivity.kt` | `OnBackInvokedDispatcher` on API 33+, shared `handleBack()` with the deprecated callback |
+| `android/.../MainActivity.kt` | `OnBackInvokedDispatcher` on API 33+, shared `handleBack()`; adds `listLaunchableApps()` / `openApp()` / `openUrl()` for the Watch feature; `getVersion()` / `installUpdate(url)` for in-app updates |
+| `android/.../LineBridge.kt` | JS bridge: `listLaunchableApps`, `openApp`, `openUrl`, `getVersion`, `installUpdate`, `canDrawOverlays`, `overlayActive`, `startOverlay`, `stopOverlay` |
+| `android/.../AndroidManifest.xml` | `<queries>` MAIN/LAUNCHER + LEANBACK_LAUNCHER + VIEW/https (package visibility for the app picker); `REQUEST_INSTALL_PACKAGES` + `FileProvider` (${applicationId}.fileprovider) for the sideload updater; `SYSTEM_ALERT_WINDOW` + `FOREGROUND_SERVICE(_SPECIAL_USE)` + `POST_NOTIFICATIONS` + `OverlayService` (`foregroundServiceType="specialUse"`) for the phone overlay |
 
 ### Fixed during this engagement (notable)
 - **A3 (P0, visual):** the settings drawer's `hidden` attribute was overridden by its `display:flex` rule, so the dimmed overlay was **visible on first paint** over the whole board. Fix: `[hidden] { display: none; }` appended to `app.css`. Verified in jsdom and real Chromium.
@@ -163,7 +223,7 @@ No API keys anywhere. `lib/rss.mjs` uses Node `Buffer` — **do not import it in
 ```bash
 cd /home/user/CoreBuildsApps/ticker
 node server.mjs          # serves on 0.0.0.0:8787
-npm test                 # node --test tests/*.test.mjs  → 77/77
+npm test                 # node --test tests/*.test.mjs  → 88/88
 node tests/soak.mjs      # standalone soak (NOT in npm test)
 ```
 Keyboard (web): D-pad move · Enter select · `S` settings · `T` ticker-only · `R` refresh · `F` fullscreen.
@@ -242,8 +302,10 @@ Node 20 (`webidl.util.markAsUncloneable is not a function`).
 
 ## 9. Verification results (all exact)
 
-- **Tests:** `npm test` → **77/77 pass** (~947 ms). 24 baseline
-  (client-slate, parser, scoreboard, ssrf) + 39 new.
+- **Tests:** `npm test` → **88/88 pass**. 24 baseline
+  (client-slate, parser, scoreboard, ssrf) + 64 new (backoff, source-registry,
+  parser-robustness, client-slate-resilience, ticker, watchdog, feedback,
+  watch, version).
 - **Accelerated in-process soak** (`node tests/soak.mjs`): 3,000 cycles ≈ 50 h →
   0 blank cycles, 1,000 flaky stale hits (last-good kept), heap growth **7.11 MB**.
 - **Real-socket server soak:** 70 cycles / 91 s against good+down mock feeds →
@@ -253,11 +315,14 @@ Node 20 (`webidl.util.markAsUncloneable is not a function`).
 - **Browser smoke (headless Chromium, 1280×720):** drawer `display:none` on first
   paint (A3 fix confirmed), ribbon transform advancing, health pill “All sources
   live”, bundled fonts loaded, crawl-mode big clock `flex`, **0 console errors**.
-- **APK manifest (aapt2):** `dev.corebuilds.line` v1.0.2 (code 3), minSdk 24,
-  targetSdk 34, permissions INTERNET/ACCESS_NETWORK_STATE/WAKE_LOCK, label
-  “Core Line”, `LEANBACK_LAUNCHER` + `tv_banner` + `uses-feature leanback`
-  present; all 26 web assets bundled (incl. `[hidden]` fix, `ticker.js`,
-  `watchdog.js`, `backoff.mjs`, `source-registry.mjs`).
+- **APK manifest (aapt2):** `dev.corebuilds.line` v1.2.0 (code 5), minSdk 24,
+  targetSdk 34, permissions INTERNET/ACCESS_NETWORK_STATE/WAKE_LOCK +
+  REQUEST_INSTALL_PACKAGES, label “Core Line”, `LEANBACK_LAUNCHER` + `tv_banner`
+  + `uses-feature leanback` present; `FileProvider`
+  (`dev.corebuilds.line.fileprovider`, exported=false, grantUriPermissions=true)
+  wired to `file_paths.xml` (cache/updates only); all 28 web assets bundled
+  (incl. `[hidden]` fix, `ticker.js`, `watchdog.js`, `backoff.mjs`,
+  `source-registry.mjs`, `watch.mjs`, `version.mjs`).
 - **Live API sample:** `leagues=mlb` + good/down mock feeds → 16 MLB events both
   calls; down feed went `502 → backoff`; health `degraded:1, stale:0`.
 
@@ -265,7 +330,7 @@ Node 20 (`webidl.util.markAsUncloneable is not a function`).
 
 ## 10. What remains (prioritized)
 
-1. **[USER TO SUPPLY] Sideload + first-run + manual checklist** — `releases/CoreLine-debug-v1.0.2.apk` onto a Shield/Google TV/Fire TV (Fire OS 7+); run `VERIFICATION.md` §5 (first launch crawls offline, airplane-mode 2 min, malformed/empty feed injection, full D-pad walk incl. reorder + interval + position, back-behavior, ≥6 h memory soak, 10-foot legibility). Report which device/emulator.
+1. **[USER TO SUPPLY] Sideload + first-run + manual checklist** — `releases/CoreLine-debug-v1.2.0.apk` onto a Shield/Google TV/Fire TV (Fire OS 7+); run `VERIFICATION.md` §5 (first launch crawls offline, airplane-mode 2 min, malformed/empty feed injection, full D-pad walk incl. reorder + interval + position, back-behavior, ≥6 h memory soak, 10-foot legibility). Also exercise Settings → Updates (check + install flow needs a published `coreline-v*` release to be fully end-to-end). Report which device/emulator.
 2. **[USER TO SUPPLY] Signed release** — land `ticker/android/github-workflow-core-line-apk.yml` at `.github/workflows/core-line-apk.yml` (owner copy, since the CI bot can't push `.github/workflows/*`); push a `coreline-v*` tag with the keystore in GitHub Secrets. Local release APK is currently unsigned by design.
 3. **Tester round-trip** — send the 2026-09-04 fixes back: rerun the pasted feed, confirm the rerun no longer shows LIVE, confirm college games appear, try the 📡 feed tab + ★ favorites + sport super-tabs on the TV. Ask for the **exact title** of any item that still shows a wrong LIVE/FINAL badge so the parser rules can be tuned (a title alone can't always distinguish "NFL Live" the show from a live game).
 4. **Repo hygiene — `.git` was lost from the workspace** (code is intact): re-`git init` or re-clone from `brevityA/CoreBuildsApps` and re-apply `ticker/` before pushing. The zip in `releases/../` ships the full `ticker/` tree, so nothing is missing.
@@ -285,7 +350,8 @@ Product: Android/TV sports + channel ticker (chyron). "Team vs Team · ESPN, TSN
 Sideload APK. Public scoreboards + user-pasted RSS only. Same-Wi-Fi QR to add feeds.
 First launch already crawling — never blank, never a settings wall.
 
-Status as of 2026-09-04 (audit + polish + supporter-feedback round, all shipped):
+Status as of 2026-09-04 (audit + reliability + polish + feedback + D-pad + in-app
+updates rounds, all shipped):
 - Audit: ticker/AUDIT.md (A1–F7, each with file:line, severity, fix).
 - Reliability: per-source backoff + last-good (lib/backoff.mjs,
   lib/source-registry.mjs), hardened parser (lib/parser.mjs), client/server
@@ -295,14 +361,25 @@ Status as of 2026-09-04 (audit + polish + supporter-feedback round, all shipped)
 - Feedback round: LIVE-on-rerun parser fix, NCAAF/NCAAB by default, per-feed 📡
   tabs, sport super-tabs, card ★ + settings team-picker favorites, rss.app JSON,
   fuller [data-tv] 10-foot pass. See VERIFICATION.md §8–8.1.
-- Verified: npm test = 77/77; 50 h soak + real-socket soak = 0 blank, ~0 memory
+- D-pad/settings/watch-apps round: spatial D-pad nav (tv.js), left-rail settings,
+  Watch-apps assignment. See VERIFICATION.md §8.2.
+- Updates + polish round: in-app updates (lib/version.mjs + UpdateManager.kt +
+  FileProvider + Updates pane) and a full cosmetic polish pass; local version is
+  1.2.0 (code 5). See VERIFICATION.md §8.3.
+- Overlay round: phone floating ticker over other apps (OverlayService.kt,
+  translucent touch-through window reusing the same WebView app). TV overlay /
+  home-screen widget are NOT possible on Android TV — see VERIFICATION.md §8.4.
+- Verified: npm test = 88/88; 50 h soak + real-socket soak = 0 blank, ~0 memory
   growth; headless-Chromium smoke clean. See ticker/VERIFICATION.md.
-- Built: ticker/releases/CoreLine-debug-v1.0.2.apk (installable) and
-  CoreLine-release-unsigned-v1.0.2.apk. Manifest/leanback/assets verified.
+- Built: ticker/releases/CoreLine-debug-v1.2.0.apk (installable) and
+  CoreLine-release-unsigned-v1.2.0.apk. Manifest/leanback/FileProvider/assets
+  verified.
 
 Remaining (owner actions, cannot be done in sandbox — no device, no /dev/kvm):
-1. Sideload the debug APK and run VERIFICATION.md §5 manual/soak checklist.
-2. Land .github/workflows/core-line-apk.yml and tag coreline-v* for a signed release.
+1. Sideload the debug APK and run VERIFICATION.md §5 manual/soak checklist
+   (incl. Settings → Updates).
+2. Land .github/workflows/core-line-apk.yml and tag coreline-v1.2.0 for a signed
+   release — this also makes the in-app updater live for existing 1.1.0 devices.
 
 Hard no: video playback, IPTV playlists, bundled illegal sources, native rewrite
 of the board (WebView + shared JS parser IS the product).

--- a/ticker/VERIFICATION.md
+++ b/ticker/VERIFICATION.md
@@ -10,7 +10,7 @@ Chromium (Playwright) for browser smoke tests, and JDK 21 + Android SDK 34 for t
 cd ticker && npm test
 ```
 
-**77 tests, 77 passing** (up from the 24 baseline tests). New coverage:
+**88 tests, 88 passing** (up from the 24 baseline tests). New coverage:
 
 | File | Covers (req) |
 |---|---|
@@ -21,6 +21,8 @@ cd ticker && npm test
 | `tests/ticker.test.mjs` | constant px/s loop math, wrap at seq width, short-content padding, dt clamping, stop/restart keeps position (req 8) |
 | `tests/watchdog.test.mjs` | stall → `onStall` after two unchanged samples, no false stalls while moving, wake on visibility, background pages ignored (req 6) |
 | `tests/feedback.test.mjs` | pins the 2026-09-04 supporter complaints: live/final/replay status rules, college leagues in defaults, `leagueFromCategory`, RSS/JSON category bucketing, rss.app JSON shape |
+| `tests/watch.test.mjs` | `lib/watch.mjs`: app-picker sort/dedupe, `leagueIdForLabel`, `espnWebUrl` (game page + search fallback), `watchChoiceFor` assignment |
+| `tests/version.test.mjs` | `lib/version.mjs`: semver ordering, `coreline-v*` tag parsing, newest-release selection, update-status (newer / up-to-date / no-asset) |
 
 ## 2. Failure injection (req 14)
 
@@ -81,7 +83,7 @@ Loaded the real app at `http://localhost:8787/` (1280×720 viewport), waited for
 
 ## 5. Manual / soak checklist (run on device)
 
-- [ ] Sideload `releases/CoreLine-debug-v1.0.2.apk` on a Shield / Google TV / Fire TV (Fire OS 7+).
+- [ ] Sideload `releases/CoreLine-debug-v1.2.0.apk` on a Shield / Google TV / Fire TV (Fire OS 7+).
 - [ ] First launch (no network): crawl is populated (demo slate + bundled sample) — **never a blank screen**.
 - [ ] Airplane mode 2 min → health pill turns amber ("retrying") and the ribbon keeps moving with last-good content; re-enable network → pill returns green within one refresh interval.
 - [ ] Inject a malformed feed (a URL that returns HTML or garbage) via Settings → Add; the other feeds and scoreboards keep scrolling.
@@ -91,25 +93,27 @@ Loaded the real app at `http://localhost:8787/` (1280×720 viewport), waited for
 - [ ] Multi-hour soak (≥ 6 h): note memory in `adb shell dumpsys meminfo dev.corebuilds.line` at T+0 and T+6 h; the ribbon must still be moving (watchdog restarts it if it ever stalls).
 - [ ] Screen off → on (and daydream if enabled): the clock is correct on resume and the ribbon is moving.
 - [ ] 10-foot check: ticker and card text legible from ~3 m; no content under overscan on a classic TV (adjust `--overscan` if needed).
+- [ ] Settings → Updates: shows the installed version; “Check for updates” reaches the GitHub release feed; with a newer `coreline-v*` release published, “Download & install” hands the APK to the system installer (unknown-sources prompt appears).
 
 ## 6. Release build (req 15)
 
 Both variants built in-sandbox with JDK 21 + Android SDK 34 (AGP 8.5.2 / Kotlin 1.9.24 / Gradle 8.7, memory capped at 896 MB heap + 2 GB swap):
 
-- **`releases/CoreLine-debug-v1.0.2.apk`** (1.82 MB, debug-signed, installable) — the sideload artifact.
-- **`releases/CoreLine-release-unsigned-v1.0.2.apk`** (1.29 MB) — release variant compiles; signing is skipped because `KEYSTORE_PATH` is unset (by design: `app/build.gradle.kts` only signs release when a keystore is provided).
+- **`releases/CoreLine-debug-v1.2.0.apk`** (3.08 MB, debug-signed, installable) — the sideload artifact.
+- **`releases/CoreLine-release-unsigned-v1.2.0.apk`** (2.26 MB) — release variant compiles; signing is skipped because `KEYSTORE_PATH` is unset (by design: `app/build.gradle.kts` only signs release when a keystore is provided).
 
 APK manifest verification (aapt2):
 ```
-package: dev.corebuilds.line  versionCode 3  versionName 1.0.2
+package: dev.corebuilds.line  versionCode 5  versionName 1.2.0
 sdkVersion 24   targetSdkVersion 34
-permissions: INTERNET, ACCESS_NETWORK_STATE, WAKE_LOCK
+permissions: INTERNET, ACCESS_NETWORK_STATE, WAKE_LOCK, REQUEST_INSTALL_PACKAGES
 label: "Core Line"
 ```
 
 APK contents verified:
-- All 26 web assets bundled (`index.html`, `css/app.css`, `js/*.js`, `lib/*.mjs`, `fonts/*.woff2`, bundled sample feed) — including the `[hidden]` CSS fix, `watchdog.js`, `ticker.js`, `backoff.mjs`, `source-registry.mjs`.
+- All 28 web assets bundled (`index.html`, `css/app.css`, `js/*.js`, `lib/*.mjs`, `fonts/*.woff2`, bundled sample feed) — including the `[hidden]` CSS fix, `watchdog.js`, `ticker.js`, `backoff.mjs`, `source-registry.mjs`, `watch.mjs`, `version.mjs`.
 - `android.software.leanback` uses-feature + `CATEGORY_LEANBACK_LAUNCHER` + `@drawable/tv_banner` present → the app appears in the Android TV launcher.
+- `FileProvider` authority `dev.corebuilds.line.fileprovider` (exported=false, grantUriPermissions=true) backed by `file_paths.xml` exposing only `cache/updates/` → the sideload updater can hand the downloaded APK to the system installer.
 
 **Clean install + first run on a real Android TV target (or emulator) remains [USER TO SUPPLY]** — say which device/emulator when reporting back; the sandbox has no display. The production signing path is the CI workflow `ticker/android/github-workflow-core-line-apk.yml` (land at `.github/workflows/core-line-apk.yml`): `npm test` then `assembleDebug` on push/PR, and a **signed release** on a `coreline-v*` tag with the keystore from GitHub Secrets.
 
@@ -141,3 +145,151 @@ Owner approved: sport super-tabs, favorites via card-star + checklist, and a ful
 - **Sport super-tabs** — `SPORT_GROUPS` in `lib/scoreboard.mjs`; filter chips `Football` (= NFL+NCAAF), `Basketball` (= NBA+NCAAB+WNBA), `Baseball`, `Hockey`, `Soccer` (= EPL+MLS+UCL), `MMA`, `Racing`, shown before league chips when that sport has events. Verified: `Football 42`, `Basketball 63` chips appear; clicking Basketball filters cards to NBA/WNBA/NCAAB only.
 - **Favorites on TV** — (a) every game card has a ★ button (focusable; OK on it toggles both teams, filled when favorited); (b) settings has a `teamPicker` checklist of teams from the **current tab** (capped at 100, D-pad operable) that toggles favorites without typing. Verified: card ★ → `favorites: "KC, BUF"`; picker chip → appended.
 - **10-foot pass** — `[data-tv]` now: root `font-size: 20px`, grid `minmax(360px,1fr)` (fewer cards/row), 5px focus ring, bigger chips/badges/scores, header `.stats` counts hidden. Verified at 1920×1080 `?tv=1`: stats `display:none`, cards ~419px wide, focused outline `5px solid`, 0 console errors.
+
+### 8.2 Third pass — D-pad, settings, watch apps (2026-09-04)
+
+Owner asked: "make the d-pad selection better, research other Android TV apps,
+make the settings menu very refined, allow any sport application to be assigned
+to open a game." Researched official TV navigation guidance (always keep an item
+focused; uniform focus indication; D-pad must reach every control; multi-pane
+layouts for easy reachability) and the standard TV settings pattern (left rail +
+content pane — Netflix/Leanback). Shipped and verified (88/88 tests, headless
+Chromium 1920×1080 `?tv=1` + 390×844 mobile, 0 console errors):
+
+- **D-pad nav rewritten** (`public/js/tv.js`): candidates must lie in the pressed
+  direction; **cross-axis overlap preference** (the item directly above/below or
+  in-row wins over a diagonal neighbour); focused item auto-scrolls into view
+  (`scrollIntoView` + CSS `scroll-margin`/`scroll-padding`). Verified: `ArrowDown`
+  moves rail→rail, `ArrowRight` enters the active section's content, focus never
+  drops to `<body>`.
+- **Refined settings menu** (`public/index.html`, `public/css/app.css`): the
+  drawer is now a **left rail (Feeds / Scoreboards / Ticker & display / Watch
+  apps / Help) + right content pane** on TV (grid `208px 1fr`); focusing a rail
+  item switches its section (Netflix-style). On phone the rail is horizontal
+  pills. Verified: rail focus switches sections; 12 league toggles reachable.
+- **Watch apps** (new `lib/watch.mjs`, `public/js/state.js`, `public/js/app.js`,
+  `LineBridge.kt`, `MainActivity.kt`, `AndroidManifest.xml`): assign any installed
+  app per league in Settings → Watch apps; `▶ Watch` on the hero card / `▶` on
+  each game card / the `W` key opens the assigned app (or the ESPN game page in
+  the browser). Android 11+ package visibility handled with `<queries>` for
+  `MAIN`/`LAUNCHER` + `LEANBACK_LAUNCHER` (no `QUERY_ALL_PACKAGES`); launch uses
+  `getLeanbackLaunchIntentForPackage` → `getLaunchIntentForPackage` fallback.
+  Verified: APK manifest contains the `<queries>` block; `lib/watch.mjs` covered
+  by `tests/watch.test.mjs` (URL building, assignment, picker sort).
+  [UNVERIFIED on-device] the curated package-id list (`SPORTS_APPS`) drifts across
+  storefronts — the full installed-app list is what the picker actually uses.
+
+Rebuilt both APKs with the changes (now `releases/CoreLine-debug-v1.2.0.apk`,
+3.08 MB, and `CoreLine-release-unsigned-v1.2.0.apk`, 2.26 MB).
+
+### 8.3 Fourth pass — in-app updates + full UI polish (2026-09-04)
+
+Owner asked: (1) check the current GitHub version; (2) polish the UI — "leave
+nothing untouched, make the UI as clean as possible"; (3) add in-app updates
+(the app is sideloaded; no Play Store).
+
+**GitHub state checked:** `main` ticker is versionCode 4 / versionName 1.1.0
+(`coreline-v1.1.0` release, asset `coreline-release.apk`); local is now ahead at
+**versionCode 5 / versionName 1.2.0**. CI: `.github/workflows/core-line-apk.yml`
+builds on ticker pushes/PRs and releases on a `coreline-v*` tag equal to the
+Gradle `versionName` and an ancestor of `main`.
+
+Shipped and verified (88/88 tests, headless Chromium smoke, full Android build):
+
+- **In-app update logic** (`lib/version.mjs` + `tests/version.test.mjs`): pure
+  `compareVersions`, `versionFromCorelineTag`, `latestCorelineRelease`,
+  `updateStatus`. Verified against the real GitHub releases JSON — newest
+  `coreline-v*` release with a `coreline-release.apk` asset is picked.
+- **Updates settings pane** (`public/index.html`, `public/js/app.js`,
+  `public/css/app.css`): Settings → Updates shows the installed version (via
+  `LineBridge.getVersion()` → `BuildConfig.VERSION_NAME`), a “Check for updates”
+  action (GitHub releases API through the native `/api/proxy` so it passes
+  `SafeUrl`), an update banner with flattened release notes, and
+  “Download & install” on native. Verified headless: web build reports “Update
+  1.1.0 is available”, TV hint shown, 0 console errors.
+- **Android updater** (`UpdateManager.kt`, `MainActivity.kt`, `LineBridge.kt`,
+  `AndroidManifest.xml`, `file_paths.xml`, `app/build.gradle.kts`): download the
+  release APK over a host-allowlisted URL (github.com / *.github.com /
+  release-assets.githubusercontent.com / objects.githubusercontent.com, redirects
+  followed) → `cache/updates/` (80 MB cap) → `FileProvider` `ACTION_VIEW` to the
+  system installer. `REQUEST_INSTALL_PACKAGES` declared; `androidx.core:core-ktx`
+  added. Verified via aapt2: versionCode 5, permission present, FileProvider
+  present and scoped to `cache/updates/`. [UNVERIFIED on-device] the actual
+  unknown-sources prompt — no emulator/device in the sandbox.
+- **UI polish pass** (`public/css/app.css`): tactile press states, focus rings,
+  input accent colour, broadcast-style uppercase section labels with accent bar,
+  chyron edge fades into the bug/clock, tabular numerals, thin scrollbars, card
+  and badge shadows, reduced-motion support. Verified: headless smoke at
+  1440×900 / 390×844 / 1920×1080 `?tv=1` all render with 0 console errors.
+
+
+### 8.4 Fifth pass — phone floating overlay (2026-09-04)
+
+Owner asked to "allow the ticker to display as a widget or over the screen."
+Platform reality (researched live, cited):
+
+- **TV home-screen widget** — not supported. Launchers decide widget support and
+  Google's TV launcher (and Fire TV) deliberately omit it; only niche
+  third-party launchers add it (StackOverflow 76549233).
+- **TV ticker over other apps** — not supported. Android TV has no
+  SYSTEM_ALERT_WINDOW for a sideloaded app, and PIP is reserved for video. The
+  supported idle path is a Daydream **screen saver**, which on many Google TV /
+  Fire OS devices can only be set via a one-time ADB
+  `settings put secure screensaver_components …` (AerialViews README).
+- **Phone home widget** — possible but RemoteViews only (no animated crawl).
+- **Phone floating overlay** — feasible: translucent always-on-top window
+  hosting the existing WebView renderer. **Built this.**
+
+Shipped and verified (88/88 tests, headless overlay smoke, full Android build):
+
+- **OverlayService.kt** — foreground service (`foregroundServiceType=specialUse`
+  + `PROPERTY_SPECIAL_USE_FGS_SUBTYPE`), translucent `TYPE_APPLICATION_OVERLAY`
+  (pre-26: `TYPE_PHONE`) window, `FLAG_NOT_FOCUSABLE | FLAG_NOT_TOUCH_MODAL |
+  FLAG_NOT_TOUCHABLE`, full-width ~56dp strip, transparent WebView loading the
+  same app with `?native=1&overlay=1`. Ongoing notification with a Stop action.
+- **Reuse, not rewrite** — the overlay is the same `index.html`; it shares the
+  parser, the `/api/proxy` data path, and (same origin) the app's localStorage,
+  so speed/theme/position/feeds all carry over. `[data-overlay]` CSS strips the
+  topbar/leagues/stage/drawer and renders only the chyron.
+- **Control** — Settings → Ticker & display gains a "Floating ticker over other
+  apps (phone)" checkbox (native + non-TV only). Toggling on calls
+  `LineBridge.startOverlay()`, which opens the system "display over other apps"
+  screen if permission is missing, and refuses on TV (`isTelevision()`).
+- **Verified**: aapt2 shows `SYSTEM_ALERT_WINDOW`, `FOREGROUND_SERVICE`,
+  `FOREGROUND_SERVICE_SPECIAL_USE`, `POST_NOTIFICATIONS` and the `OverlayService`
+  with `foregroundServiceType=0x40000000 (specialUse)`. Headless Chromium
+  `?native=1&overlay=1` at 390×64: `data-overlay` set, topbar/stage/drawer hidden,
+  chyron visible, body background transparent, ticks render, no JS errors.
+  [UNVERIFIED on-device] the actual overlay window over another app and the
+  unknown-sources/overlay permission prompts — no device/emulator in the sandbox.
+
+### 8.5 Sixth pass — Android TV UI consistency (2026-09-04)
+
+Owner: "Fix the UI … it is too inconsistent on Android TV, blown out."
+
+Measured the TV (1920×1080 `?tv=1`) before fixing: text sizes were scattered
+from **13.2px** (health pill, `.when`) up to **68px** (hero `.score`), the
+checkboxes were **16px** (smaller than their own labels), and the square
+controls came in four sizes (44/46/52/56px). The root cause: the 10-foot pass
+had a 20px root (1.25× phone) plus a pile of ad-hoc `[data-tv]` rem overrides
+that each assumed a different multiplier (1.47×–1.77×).
+
+Fix (in `public/css/app.css`, `[data-tv]` block rewritten): ONE coherent scale
+ladder on the 20px root —
+
+- micro **.8rem (16px)**: health, brand-sub, kicker, league-tag, `.when`
+- body **.95rem (19px)**: hint/fineprint, `.ch`, update-notes
+- control **1.1rem (22px)**: rail-item, ghost, team-chip, check labels, inputs
+- title **1.3rem (26px)**: block h3, watch-league, chip
+- display **2rem (40px)**: brand-name, drawer h2, `.gt .who`/`.sc`, tick, clock
+
+plus: every square control 56px (48px in-card); hero numerals tamed to
+abbr 48px / score 56px (with an `.abbr` ellipsis guard so a long abbreviation
+can't overflow its 88px column); checkboxes 26px with `flex: 0 0 auto`;
+focus ring 6px.
+
+Verified headless (pinned in `tests/smoke-updates.mjs`): health ≥16px,
+`.when` ≥16px, chyron tick 40px, card team names == brand size (40px == 40px),
+abbr ≤ score, no abbreviation overflow; 88/88 unit tests; desktop/mobile/TV/
+overlay smoke all 0 console errors. Phone layout untouched (all changes under
+`[data-tv]`).

--- a/ticker/android/app/build.gradle.kts
+++ b/ticker/android/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
         applicationId = "dev.corebuilds.line"
         minSdk = 24
         targetSdk = 34
-        versionCode = 4
-        versionName = "1.1.0"
+        versionCode = 5
+        versionName = "1.2.0"
     }
 
     signingConfigs {
@@ -52,6 +52,11 @@ android {
     buildFeatures {
         buildConfig = true
     }
+}
+
+dependencies {
+    // FileProvider + main-executor for the sideload updater (UpdateManager.kt).
+    implementation("androidx.core:core-ktx:1.13.1")
 }
 
 val webPublic = rootProject.file("../public")

--- a/ticker/android/app/src/main/AndroidManifest.xml
+++ b/ticker/android/app/src/main/AndroidManifest.xml
@@ -4,10 +4,39 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <!-- Sideload updater: lets the system installer prompt for "install unknown apps". -->
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
+    <!-- Phone floating ticker: draw the chyron above other apps (granted via
+         Settings.canDrawOverlays, blocked on Android TV). -->
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <uses-feature android:name="android.software.leanback" android:required="false" />
     <uses-feature android:name="android.hardware.touchscreen" android:required="false" />
     <uses-feature android:name="android.hardware.faketouch" android:required="false" />
+
+    <!--
+      Android 11+ package visibility: let the "Watch apps" picker enumerate
+      installed launchable apps without the restricted QUERY_ALL_PACKAGES
+      permission (queryIntentActivities for MAIN/LAUNCHER + LEANBACK_LAUNCHER).
+    -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.MAIN" />
+            <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.MAIN" />
+            <category android:name="android.intent.category.LAUNCHER" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="https" />
+        </intent>
+    </queries>
 
     <application
         android:allowBackup="true"
@@ -19,6 +48,26 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.CoreLine"
         android:usesCleartextTraffic="true">
+
+        <!-- Exposes cache/updates/ to the system package installer for the sideload updater. -->
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
+
+        <service
+            android:name=".OverlayService"
+            android:exported="false"
+            android:foregroundServiceType="specialUse">
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="Always-on-top sports ticker overlay (phone/tablet)" />
+        </service>
 
         <activity
             android:name=".MainActivity"

--- a/ticker/android/app/src/main/java/dev/corebuilds/line/LineBridge.kt
+++ b/ticker/android/app/src/main/java/dev/corebuilds/line/LineBridge.kt
@@ -18,4 +18,40 @@ class LineBridge(private val activity: MainActivity) {
     fun setKeepAwake(on: Boolean) {
         activity.setKeepAwake(on)
     }
+
+    /** JSON array of installed launchable apps for the "Watch apps" picker. */
+    @JavascriptInterface
+    fun listLaunchableApps(): String = activity.listLaunchableApps()
+
+    /** Launch an installed app by package id. Returns success. */
+    @JavascriptInterface
+    fun openApp(packageName: String): Boolean = activity.openApp(packageName)
+
+    /** Open a URL in the system browser. Returns success. */
+    @JavascriptInterface
+    fun openUrl(url: String): Boolean = activity.openUrl(url)
+
+    /** Current app version, e.g. "1.2.0". */
+    @JavascriptInterface
+    fun getVersion(): String = activity.getVersion()
+
+    /** Download a newer APK and hand it to the system installer (async). */
+    @JavascriptInterface
+    fun installUpdate(url: String): Boolean = activity.installUpdate(url)
+
+    /** "Display over other apps" granted? */
+    @JavascriptInterface
+    fun canDrawOverlays(): Boolean = activity.canDrawOverlays()
+
+    /** Floating ticker window currently showing? */
+    @JavascriptInterface
+    fun overlayActive(): Boolean = activity.overlayActive()
+
+    /** Start the floating ticker (opens the permission screen if needed). */
+    @JavascriptInterface
+    fun startOverlay(): Boolean = activity.startOverlay()
+
+    /** Stop the floating ticker. */
+    @JavascriptInterface
+    fun stopOverlay(): Boolean = activity.stopOverlay()
 }

--- a/ticker/android/app/src/main/java/dev/corebuilds/line/MainActivity.kt
+++ b/ticker/android/app/src/main/java/dev/corebuilds/line/MainActivity.kt
@@ -2,13 +2,16 @@ package dev.corebuilds.line
 
 import android.annotation.SuppressLint
 import android.app.Activity
+import android.content.Intent
 import android.content.pm.PackageManager
+import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import android.view.WindowManager
 import android.webkit.WebChromeClient
 import android.webkit.WebSettings
 import android.webkit.WebView
+import org.json.JSONArray
 import org.json.JSONObject
 
 class MainActivity : Activity() {
@@ -75,6 +78,119 @@ class MainActivity : Activity() {
             if (on) window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
             else window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         }
+    }
+
+    /**
+     * Enumerate installed, launchable apps for the "Watch apps" picker.
+     * Returns a JSON array [{pkg, label}] (LEANBACK_LAUNCHER first so TV apps
+     * sort naturally; deduped; self excluded). Needs the <queries> MAIN/
+     * LAUNCHER + LEANBACK_LAUNCHER block in the manifest on Android 11+.
+     */
+    @Suppress("DEPRECATION")
+    fun listLaunchableApps(): String {
+        return try {
+            val pm = packageManager
+            val seen = LinkedHashMap<String, String>()
+            val intents = listOf(
+                Intent(Intent.ACTION_MAIN).addCategory(Intent.CATEGORY_LEANBACK_LAUNCHER),
+                Intent(Intent.ACTION_MAIN).addCategory(Intent.CATEGORY_LAUNCHER),
+            )
+            for (intent in intents) {
+                val resolved = pm.queryIntentActivities(intent, 0)
+                for (ri in resolved) {
+                    val pkg = ri.activityInfo?.packageName ?: continue
+                    if (pkg == packageName) continue
+                    val label = ri.loadLabel(pm)?.toString()?.take(48) ?: pkg
+                    seen.putIfAbsent(pkg, label)
+                }
+            }
+            val arr = JSONArray()
+            for ((pkg, label) in seen) {
+                arr.put(JSONObject().put("pkg", pkg).put("label", label))
+            }
+            arr.toString()
+        } catch (err: Exception) {
+            "[]"
+        }
+    }
+
+    /** Launch an installed app by package id (Leanback launch intent first). */
+    fun openApp(packageName: String): Boolean {
+        return try {
+            var intent = packageManager.getLeanbackLaunchIntentForPackage(packageName)
+                ?: packageManager.getLaunchIntentForPackage(packageName)
+            if (intent == null) return false
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED)
+            startActivity(intent)
+            true
+        } catch (err: Exception) {
+            false
+        }
+    }
+
+    /** Current app version ("1.2.0") for the in-app Updates panel. */
+    fun getVersion(): String = dev.corebuilds.line.BuildConfig.VERSION_NAME
+
+    /** Download + hand off a newer APK to the system installer (async). */
+    fun installUpdate(url: String): Boolean = UpdateManager.downloadAndInstall(this, url)
+
+    /** Open a URL in whatever app handles it (usually the browser). */
+    fun openUrl(url: String): Boolean {
+        return try {
+            val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            startActivity(intent)
+            true
+        } catch (err: Exception) {
+            false
+        }
+    }
+
+    /** True when the OS has granted "display over other apps". */
+    fun canDrawOverlays(): Boolean = android.provider.Settings.canDrawOverlays(this)
+
+    /** Is the floating ticker window currently up? */
+    fun overlayActive(): Boolean = OverlayService.running
+
+    /** Open the system overlay-permission screen for this app. */
+    fun openOverlaySettings(): Boolean {
+        return try {
+            val intent = Intent(
+                android.provider.Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
+                Uri.parse("package:$packageName"),
+            ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            startActivity(intent)
+            true
+        } catch (err: Exception) {
+            false
+        }
+    }
+
+    /**
+     * Start the floating ticker. Returns false (no-op) on TV — Android TV has
+     * no overlay windows — or when the user hasn't granted the permission yet
+     * (in that case the system settings screen is opened for them).
+     */
+    fun startOverlay(): Boolean {
+        if (isTelevision()) return false
+        if (!android.provider.Settings.canDrawOverlays(this)) {
+            openOverlaySettings()
+            return false
+        }
+        // Android 13+: ask for notifications so the "tap to stop" control shows.
+        if (android.os.Build.VERSION.SDK_INT >= 33 &&
+            checkSelfPermission(android.Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED
+        ) {
+            requestPermissions(arrayOf(android.Manifest.permission.POST_NOTIFICATIONS), 7)
+        }
+        OverlayService.start(this)
+        return true
+    }
+
+    /** Stop the floating ticker. */
+    fun stopOverlay(): Boolean {
+        OverlayService.stop(this)
+        return true
     }
 
     @Deprecated("Deprecated in Java")

--- a/ticker/android/app/src/main/java/dev/corebuilds/line/OverlayService.kt
+++ b/ticker/android/app/src/main/java/dev/corebuilds/line/OverlayService.kt
@@ -1,0 +1,184 @@
+package dev.corebuilds.line
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.graphics.Color
+import android.graphics.PixelFormat
+import android.os.Build
+import android.os.IBinder
+import android.view.Gravity
+import android.view.View
+import android.view.WindowManager
+import android.webkit.WebChromeClient
+import android.webkit.WebSettings
+import android.webkit.WebView
+
+/**
+ * Phone floating ticker — the chyron drawn as a translucent, non-focusable,
+ * touch-through overlay window above every other app.
+ *
+ * It reuses the SAME Core Line web app as the full screen (loaded from
+ * https://coreline.local with ?native=1&overlay=1), so it shares the parser,
+ * the /api/proxy data path, and — because both WebViews are on the same origin
+ * — the same localStorage settings as the main app. The overlay page strips
+ * everything but the chyron via the [data-overlay] CSS.
+ *
+ * Android does NOT allow this on TV (no SYSTEM_ALERT_WINDOW on Android TV);
+ * the service is phone/tablet only and the main app refuses to start it on a
+ * leanback/fire_tv device.
+ */
+class OverlayService : Service() {
+    private var windowManager: WindowManager? = null
+    private var webView: WebView? = null
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        startAsForeground()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        if (intent?.action == ACTION_STOP) {
+            stopSelf()
+            return START_NOT_STICKY
+        }
+        showOverlay()
+        return START_STICKY
+    }
+
+    private fun startAsForeground() {
+        val stopIntent = PendingIntent.getService(
+            this, 1,
+            Intent(this, OverlayService::class.java).setAction(ACTION_STOP),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+        val channelId = "coreline.overlay"
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val nm = getSystemService(NotificationManager::class.java)
+            nm?.createNotificationChannel(
+                NotificationChannel(channelId, "Floating ticker", NotificationManager.IMPORTANCE_LOW),
+            )
+        }
+        val note = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            Notification.Builder(this, channelId)
+        } else {
+            @Suppress("DEPRECATION")
+            Notification.Builder(this)
+        }
+            .setSmallIcon(dev.corebuilds.line.R.drawable.ic_notification)
+            .setContentTitle("Core Line ticker")
+            .setContentText("Running over your apps — tap to stop")
+            .setOngoing(true)
+            .setContentIntent(stopIntent)
+            .addAction(0, "Stop", stopIntent)
+            .build()
+        startForeground(OVERLAY_NOTIFICATION_ID, note)
+    }
+
+    private fun showOverlay() {
+        if (windowManager != null && webView != null) return // already up
+
+        val wm = getSystemService(WINDOW_SERVICE) as WindowManager
+        val overlayType = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY
+        } else {
+            @Suppress("DEPRECATION")
+            WindowManager.LayoutParams.TYPE_PHONE
+        }
+        val height = (56 * resources.displayMetrics.density).toInt().coerceAtLeast(96)
+        val params = WindowManager.LayoutParams(
+            WindowManager.LayoutParams.MATCH_PARENT,
+            height,
+            overlayType,
+            WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
+                or WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL
+                or WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE
+                or WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN,
+            PixelFormat.TRANSLUCENT,
+        ).apply {
+            gravity = Gravity.TOP or Gravity.FILL_HORIZONTAL
+            x = 0
+            y = 0
+        }
+
+        val wv = WebView(this).apply {
+            overScrollMode = View.OVER_SCROLL_NEVER
+            isFocusable = false
+            isFocusableInTouchMode = false
+            setBackgroundColor(Color.TRANSPARENT)
+            isVerticalScrollBarEnabled = false
+            isHorizontalScrollBarEnabled = false
+            webViewClient = LineWebClient(this@OverlayService)
+            webChromeClient = WebChromeClient()
+        }
+        configure(wv.settings)
+        wv.loadUrl("https://${LineWebClient.HOST}/index.html?native=1&overlay=1")
+
+        try {
+            wm.addView(wv, params)
+        } catch (err: Exception) {
+            stopSelf() // permission was revoked mid-flight
+            return
+        }
+        webView = wv
+        windowManager = wm
+        running = true
+    }
+
+    override fun onDestroy() {
+        running = false
+        try {
+            webView?.let { windowManager?.removeView(it) }
+        } catch (_: Exception) {
+            /* already detached */
+        }
+        webView?.removeJavascriptInterface("CoreLineNative")
+        webView?.destroy()
+        webView = null
+        windowManager = null
+        super.onDestroy()
+    }
+
+    private fun configure(settings: WebSettings) {
+        settings.javaScriptEnabled = true
+        settings.domStorageEnabled = true
+        settings.databaseEnabled = true
+        settings.cacheMode = WebSettings.LOAD_DEFAULT
+        settings.allowFileAccess = false
+        settings.allowContentAccess = false
+        settings.setSupportZoom(false)
+        settings.builtInZoomControls = false
+        settings.displayZoomControls = false
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            settings.safeBrowsingEnabled = false
+        }
+    }
+
+    companion object {
+        const val ACTION_STOP = "dev.corebuilds.line.OVERLAY_STOP"
+        const val OVERLAY_NOTIFICATION_ID = 42
+
+        @Volatile
+        var running = false
+            private set
+
+        fun start(context: Context) {
+            val intent = Intent(context, OverlayService::class.java)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                context.startForegroundService(intent)
+            } else {
+                context.startService(intent)
+            }
+        }
+
+        fun stop(context: Context) {
+            context.stopService(Intent(context, OverlayService::class.java))
+        }
+    }
+}

--- a/ticker/android/app/src/main/java/dev/corebuilds/line/UpdateManager.kt
+++ b/ticker/android/app/src/main/java/dev/corebuilds/line/UpdateManager.kt
@@ -1,0 +1,111 @@
+package dev.corebuilds.line
+
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import androidx.core.content.ContextCompat
+import androidx.core.content.FileProvider
+import java.io.File
+import java.io.FileOutputStream
+import java.net.HttpURLConnection
+import java.net.URI
+import java.net.URL
+
+/**
+ * Sideload updater — Core Line ships outside the Play Store, so updates are
+ * the classic off-Play path: download the signed APK from the GitHub release,
+ * then hand it to the system package installer (FileProvider + ACTION_VIEW).
+ *
+ * No credentials, no logging of URLs beyond the host, and only GitHub release
+ * hosts are accepted (SSRF-safe). The version CHECK itself is done in JS (via
+ * the /api/proxy fetch of the releases JSON); this object only downloads and
+ * installs.
+ */
+object UpdateManager {
+    private const val TAG = "CoreLineUpdate"
+    private const val MAX_APK_BYTES = 80L * 1024 * 1024
+
+    /** Only the GitHub release CDN is a legitimate download source. */
+    fun isAllowed(rawUrl: String?): Boolean {
+        val host = try {
+            URI(rawUrl?.trim().orEmpty()).host?.lowercase()?.trim('[', ']')
+        } catch (_: Exception) {
+            null
+        } ?: return false
+        return host == "github.com" ||
+            host == "objects.githubusercontent.com" ||
+            host == "release-assets.githubusercontent.com" ||
+            host.endsWith(".github.com")
+    }
+
+    /**
+     * Download the APK on a worker thread, then launch the system installer on
+     * the main thread. @return true when the download started (install happens
+     * asynchronously after it completes).
+     */
+    fun downloadAndInstall(context: Context, rawUrl: String): Boolean {
+        if (!isAllowed(rawUrl)) return false
+        val cacheDir = File(context.cacheDir, "updates").apply { mkdirs() }
+        val apk = File(cacheDir, "coreline-update.apk")
+        val main = ContextCompat.getMainExecutor(context)
+        Thread {
+            val ok = try {
+                download(rawUrl, apk)
+            } catch (err: Exception) {
+                Log.w(TAG, "update download failed", err)
+                false
+            }
+            main.execute {
+                if (ok) launchInstaller(context, apk)
+                else apk.delete()
+            }
+        }.start()
+        return true
+    }
+
+    private fun download(rawUrl: String, apk: File): Boolean {
+        val conn = URL(rawUrl).openConnection() as HttpURLConnection
+        try {
+            conn.instanceFollowRedirects = true
+            conn.connectTimeout = 20_000
+            conn.readTimeout = 180_000
+            conn.setRequestProperty("User-Agent", "CoreLineUpdater/1.0")
+            if (conn.responseCode !in 200..299) return false
+            conn.inputStream.use { input ->
+                FileOutputStream(apk).use { out ->
+                    val buf = ByteArray(64 * 1024)
+                    var total = 0L
+                    while (true) {
+                        val n = input.read(buf)
+                        if (n < 0) break
+                        total += n
+                        if (total > MAX_APK_BYTES) {
+                            throw IllegalStateException("update larger than ${MAX_APK_BYTES / (1024 * 1024)} MB")
+                        }
+                        out.write(buf, 0, n)
+                    }
+                }
+            }
+            return apk.length() > 0
+        } finally {
+            conn.disconnect()
+        }
+    }
+
+    private fun launchInstaller(context: Context, apk: File) {
+        val uri = FileProvider.getUriForFile(
+            context,
+            "${context.packageName}.fileprovider",
+            apk,
+        )
+        val intent = Intent(Intent.ACTION_VIEW).apply {
+            setDataAndType(uri, "application/vnd.android.package-archive")
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        try {
+            context.startActivity(intent)
+        } catch (err: Exception) {
+            Log.w(TAG, "no package installer available", err)
+        }
+    }
+}

--- a/ticker/android/app/src/main/res/drawable/ic_notification.xml
+++ b/ticker/android/app/src/main/res/drawable/ic_notification.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- Minimal ticker-strip glyph for the foreground-service notification. -->
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M3,5h18v2H3zM3,11h18v2H3zM3,17h11v2H3z" />
+</vector>

--- a/ticker/android/app/src/main/res/xml/file_paths.xml
+++ b/ticker/android/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- FileProvider paths for the sideload updater: expose only cache/updates/. -->
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <cache-path name="updates" path="updates/" />
+</paths>

--- a/ticker/lib/version.mjs
+++ b/ticker/lib/version.mjs
@@ -1,0 +1,78 @@
+/**
+ * In-app update checks (sideloaded, no Play Store).
+ * The Android shell downloads + installs; this module only compares versions
+ * and shapes the update payload. Pure logic — unit tested.
+ */
+
+/**
+ * Compare two dotted semver-ish version strings (e.g. "1.2.0" vs "1.10.3").
+ * Returns -1 / 0 / 1. Non-numeric segments compare as strings.
+ */
+export function compareVersions(a, b) {
+  const pa = String(a || '').trim().split('.');
+  const pb = String(b || '').trim().split('.');
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const x = pa[i] ?? '0';
+    const y = pb[i] ?? '0';
+    const nx = Number(x);
+    const ny = Number(y);
+    if (!Number.isNaN(nx) && !Number.isNaN(ny) && nx !== ny) {
+      return nx < ny ? -1 : 1;
+    }
+    if (x !== y) return x < y ? -1 : 1;
+  }
+  return 0;
+}
+
+/** Strip the "coreline-v" prefix from a release tag → "1.2.0" (or null). */
+export function versionFromCorelineTag(tag) {
+  const m = String(tag || '').trim().match(/^coreline-v(\d+\.\d+\.\d+.*)$/i);
+  return m ? m[1] : null;
+}
+
+/**
+ * Pick the newest coreline-v release from a GitHub "releases" JSON array
+ * (as returned by https://api.github.com/repos/OWNER/REPO/releases).
+ * Returns { tag, version, apkUrl, notes } or null when there is none.
+ */
+export function latestCorelineRelease(releases, apkName = 'coreline-release.apk') {
+  if (!Array.isArray(releases)) return null;
+  let best = null;
+  for (const r of releases) {
+    const version = versionFromCorelineTag(r?.tag_name);
+    if (!version) continue;
+    if (!best || compareVersions(version, best.version) > 0) {
+      const apk = (r.assets || []).find((a) => a?.name === apkName);
+      best = {
+        tag: r.tag_name,
+        version,
+        apkUrl: apk?.browser_download_url || null,
+        notes: r.body || '',
+      };
+    }
+  }
+  return best;
+}
+
+/**
+ * Build the update status payload for the UI.
+ * currentVersion is the running app's version (BuildConfig.VERSION_NAME).
+ */
+export function updateStatus(releases, currentVersion, apkName) {
+  const current = String(currentVersion || '0').trim();
+  const latest = latestCorelineRelease(releases, apkName);
+  if (!latest) {
+    return { ok: true, current, latest: null, newer: false, checked: true };
+  }
+  return {
+    ok: true,
+    current,
+    latest: latest.version,
+    tag: latest.tag,
+    apkUrl: latest.apkUrl,
+    notes: latest.notes,
+    newer: compareVersions(latest.version, current) > 0,
+    checked: true,
+  };
+}

--- a/ticker/lib/watch.mjs
+++ b/ticker/lib/watch.mjs
@@ -1,0 +1,100 @@
+/**
+ * "Watch" integration — assign any installed sports/streaming app (or the web)
+ * to open a game, so a viewer can jump from the ticker into the app that
+ * actually plays the broadcast. Pure logic shared by the UI; the Android shell
+ * does the real package query + launch (LineBridge.kt + manifest <queries>).
+ */
+
+import { LEAGUES } from './scoreboard.mjs';
+
+/** Sentinel meaning "open the game page in the web browser". */
+export const WATCH_WEB = 'web';
+
+/**
+ * Curated, best-effort list of well-known sports/streaming apps. Used only to
+ * sort the picker (familiar apps first); the native shell also returns the
+ * device's full installed-app list so a user can assign ANY app.
+ * [UNVERIFIED] package ids drift across storefronts/versions — never treat this
+ * list as authoritative.
+ */
+export const SPORTS_APPS = [
+  { pkg: 'com.espn.score_center', label: 'ESPN' },
+  { pkg: 'com.foxsports.videogo', label: 'Fox Sports' },
+  { pkg: 'com.nbcuni.nbcsports', label: 'NBC Sports' },
+  { pkg: 'com.peacocktv.peacockandroid', label: 'Peacock' },
+  { pkg: 'com.cbs.ott', label: 'Paramount+' },
+  { pkg: 'com.paramountplus.android', label: 'Paramount+' },
+  { pkg: 'com.dazn', label: 'DAZN' },
+  { pkg: 'com.google.android.apps.youtube.unplugged', label: 'YouTube TV' },
+  { pkg: 'com.hulu.livingroomplus', label: 'Hulu' },
+  { pkg: 'com.sling', label: 'Sling TV' },
+  { pkg: 'tv.fubo.mobile', label: 'FuboTV' },
+  { pkg: 'com.amazon.amazonvideo.livingroom', label: 'Prime Video' },
+  { pkg: 'com.wbd.stream', label: 'Max' },
+  { pkg: 'com.bellmedia.tsn', label: 'TSN' },
+  { pkg: 'com.rogers.sportsnet', label: 'Sportsnet' },
+  { pkg: 'com.apple.atve.android.appletv', label: 'Apple TV' },
+];
+
+const CURATED = new Map(SPORTS_APPS.map((a) => [a.pkg, a.label]));
+
+/**
+ * Order an installed-app list for the picker: curated sports apps first (in
+ * curated order), then everything else alphabetically. Dedupes by package.
+ * @param {Array<{pkg:string,label:string}>} apps raw list from the shell
+ */
+export function sortAppsForPicker(apps = []) {
+  const byPkg = new Map();
+  for (const a of apps) {
+    if (!a || typeof a.pkg !== 'string' || !a.pkg) continue;
+    const label = String(a.label || a.pkg);
+    if (!byPkg.has(a.pkg)) byPkg.set(a.pkg, { pkg: a.pkg, label });
+  }
+  const curated = [];
+  const rest = [];
+  for (const a of byPkg.values()) {
+    if (CURATED.has(a.pkg)) {
+      a.label = CURATED.get(a.pkg);
+      curated.push(a);
+    } else {
+      rest.push(a);
+    }
+  }
+  const curatedOrder = new Map(SPORTS_APPS.map((a, i) => [a.pkg, i]));
+  curated.sort((x, y) => (curatedOrder.get(x.pkg) ?? 99) - (curatedOrder.get(y.pkg) ?? 99));
+  rest.sort((x, y) => x.label.localeCompare(y.label));
+  return [...curated, ...rest];
+}
+
+/** Map a league LABEL (event.league, e.g. "NFL") back to its LEAGUES id. */
+export function leagueIdForLabel(label) {
+  for (const [id, l] of Object.entries(LEAGUES)) {
+    if (l.label === label) return id;
+  }
+  return null;
+}
+
+/**
+ * Build the best web URL for a game. ESPN-sourced events with a numeric id get
+ * the canonical ESPN game page; everything else falls back to an ESPN search.
+ */
+export function espnWebUrl(event) {
+  const leagueId = leagueIdForLabel(event?.league);
+  const espnPath = leagueId ? (LEAGUES[leagueId]?.espn || '').split('/').pop() : '';
+  const gameId = /^\d+$/.test(String(event?.id || '')) ? event.id : null;
+  if (espnPath && gameId) {
+    return `https://www.espn.com/${espnPath}/game/_/gameId/${gameId}`;
+  }
+  const q = [event?.away?.name, event?.home?.name].filter(Boolean).join(' vs ') || event?.rawTitle || event?.league || '';
+  return `https://www.espn.com/search/_/q/${encodeURIComponent(q)}`;
+}
+
+/**
+ * Resolve what should open a given event: an app package id, or 'web'.
+ * Assignment is keyed by league id; falls back to the league label, then web.
+ */
+export function watchChoiceFor(watchApps, leagueLabel) {
+  const id = leagueIdForLabel(leagueLabel);
+  const choice = (watchApps && (watchApps[id] || watchApps[leagueLabel])) || WATCH_WEB;
+  return choice === WATCH_WEB ? WATCH_WEB : String(choice);
+}

--- a/ticker/package.json
+++ b/ticker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "core-line",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "type": "module",
   "description": "Core Line — sports and channel RSS ticker for Android, TV, and the web",

--- a/ticker/public/css/app.css
+++ b/ticker/public/css/app.css
@@ -404,10 +404,80 @@ input, select {
 .pair-url { font-size: .95rem; word-break: break-all; margin: 8px 0 4px; color: var(--text); }
 .pair-code { font-family: var(--font); font-size: 2.2rem; letter-spacing: .28em; color: var(--line); font-weight: 800; margin-bottom: 10px; }
 .check { display: flex; gap: 10px; align-items: flex-start; color: var(--muted); font-size: .86rem; }
-.check input { width: 18px; height: 18px; margin-top: 2px; }
+.check input { width: 18px; height: 18px; margin-top: 2px; flex: 0 0 auto; }
 .chip-grid { display: flex; flex-wrap: wrap; gap: 8px; }
 .split { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
 .split label { display: grid; gap: 6px; font-size: .8rem; color: var(--muted); }
+.split.checks { margin-top: 18px; }
+
+/* ---- settings: rail + section panes ------------------------------------ */
+.drawer-body { display: flex; flex-direction: column; min-height: 0; }
+.drawer-rail {
+  display: flex; gap: 8px; overflow-x: auto; margin-bottom: 20px;
+  padding: 2px; scrollbar-width: none;
+}
+.drawer-rail::-webkit-scrollbar { display: none; }
+.rail-item {
+  display: inline-flex; align-items: center; gap: 8px;
+  border: 1px solid var(--border); background: var(--panel); color: var(--muted);
+  border-radius: 999px; padding: 9px 16px; font-size: .95rem; letter-spacing: .04em;
+  white-space: nowrap; cursor: pointer;
+}
+.rail-item:hover { border-color: var(--line); color: var(--text); }
+.rail-item.is-active { color: #041018; background: var(--line); border-color: var(--line); }
+.rail-ic { font-size: 1.02rem; }
+.drawer-sections { min-height: 0; }
+.drawer-section { display: none; }
+.drawer-section.is-active { display: block; }
+
+/* ---- watch apps -------------------------------------------------------- */
+.watch-list { display: grid; gap: 10px; }
+.watch-row { display: grid; grid-template-columns: 96px 1fr; gap: 12px; align-items: center; }
+.watch-league { font-family: var(--font); font-weight: 700; letter-spacing: .08em; color: var(--text); }
+.watch-league::before {
+  content: ""; display: inline-block; width: 8px; height: 8px; border-radius: 2px;
+  margin-right: 8px; background: var(--acc, var(--line));
+}
+.watch-row select { width: 100%; }
+.hint.small { font-size: .72rem; }
+
+/* ---- updates panel ------------------------------------------------------ */
+.update-row { display: flex; justify-content: space-between; align-items: baseline; gap: 12px; padding: 2px 0; }
+.update-label { color: var(--muted); font-size: .82rem; letter-spacing: .04em; }
+.update-value { font-family: var(--font); font-size: 1.1rem; letter-spacing: .06em; color: var(--text); }
+.update-note { color: var(--muted); font-size: .82rem; margin: 8px 0; }
+.update-note.ok { color: #39d98a; }
+.update-note.error { color: var(--live); }
+.update-note.checking { color: var(--line); }
+.update-note.checking::before { content: ""; display: inline-block; width: 8px; height: 8px; border-radius: 50%; background: var(--line); margin-right: 8px; animation: pulse 1.2s ease-in-out infinite; }
+.update-banner {
+  border: 1px solid rgba(0,212,255,.35);
+  background: var(--line-dim);
+  border-radius: 14px;
+  padding: 14px 16px;
+  margin: 10px 0;
+}
+.update-banner-title { font-family: var(--font); font-size: 1.25rem; letter-spacing: .04em; color: var(--line); }
+.update-notes { color: var(--muted); font-size: .78rem; line-height: 1.5; margin-top: 6px; white-space: pre-wrap; word-break: break-word; }
+.update-row + .update-banner, .update-row + .update-note { margin-top: 10px; }
+
+.watch-btn {
+  font-family: var(--font); font-weight: 700; letter-spacing: .08em;
+  background: var(--line); color: #041018; border: none; border-radius: 999px;
+  padding: 10px 18px; font-size: 1.05rem; display: inline-flex; align-items: center; gap: 6px;
+  cursor: pointer;
+}
+.watch-btn:hover, .watch-btn:focus-visible, [data-tv] .watch-btn:focus { filter: brightness(1.15); }
+.watch-mini {
+  width: 30px; height: 30px; border-radius: 50%; display: grid; place-items: center;
+  border: 1px solid var(--border); background: transparent; color: var(--line); font-size: .8rem; padding: 0;
+  cursor: pointer;
+}
+.watch-mini:hover, .watch-mini:focus-visible, [data-tv] .watch-mini:focus { background: var(--line-dim); border-color: var(--line); }
+
+/* ---- D-pad scroll-into-view breathing room ----------------------------- */
+.stage { scroll-padding: 14px 0; }
+.focusable { scroll-margin: 14px; }
 
 .chyron {
   height: var(--chyron-h);
@@ -554,38 +624,118 @@ input, select {
   .badge.live { animation: none; }
 }
 
-/* ---- TV / 10-foot scaling (AUDIT F3) ---------------------------------- */
+/* ========================================================================
+   TV / 10-foot pass (AUDIT F3).
+   ONE coherent scale ladder so nothing is blown out or stranded tiny:
+   root 20px (= 1.25x phone) is applied uniformly, then every role sits on the
+   SAME rung — micro .8rem / body .95rem / control 1.1rem / title 1.3rem /
+   display 2rem. Every square control is 56px (48px in-card). No element may
+   skip the ladder; that's what made TV look inconsistent.
+   ======================================================================== */
 [data-tv] {
   --chyron-h: 96px;
   --overscan: 40px;
-  /* Scale the whole rem-based UI ~25% for a 10-foot couch, not a phone. */
   font-size: 20px;
 }
-[data-tv] .tick { font-size: 2.05rem; letter-spacing: .04em; }
-[data-tv] .tick .k { font-size: 1.4rem; }
-[data-tv] .chyron-clock { font-size: 2.1rem; min-width: 150px; }
-[data-tv] .bug-live { font-size: .92rem; }
-[data-tv] .bug-name { font-size: 1.7rem; }
-[data-tv] .league-chip { font-size: 1.45rem; padding: 12px 24px; }
-[data-tv] .gt .who, [data-tv] .gt .sc { font-size: 2.2rem; }
-[data-tv] .badge { font-size: 1.05rem; padding: 4px 12px; }
-[data-tv] .league-tag { font-size: .85rem; }
-[data-tv] .ch { font-size: 1rem; padding: 3px 8px; }
-[data-tv] .game { min-height: 200px; padding: 20px 22px 18px; }
-[data-tv] .grid { grid-template-columns: repeat(auto-fill, minmax(360px, 1fr)); gap: 16px; }
-[data-tv] .fav-star { width: 46px; height: 46px; font-size: 1.4rem; }
-[data-tv] .team-chip { font-size: 1.1rem; padding: 8px 16px; }
-[data-tv] .icon-btn { width: 56px; height: 56px; font-size: 1.4rem; }
-[data-tv] .drawer-panel { width: min(640px, 100%); }
-[data-tv] .drawer h2 { font-size: 2rem; }
-[data-tv] .drawer .block h3 { font-size: 1.05rem; }
-[data-tv] .drawer input, [data-tv] .drawer select { font-size: 1.05rem; padding: 14px; }
-[data-tv] .ghost { padding: 10px 14px; font-size: 1rem; }
-[data-tv] .stat b { font-size: 1.8rem; }
+
+/* chyron (broadcast strip) */
+[data-tv] .tick { font-size: 2rem; letter-spacing: .04em; }
+[data-tv] .tick .k { font-size: 1.2rem; }
+[data-tv] .chyron-clock { font-size: 2rem; min-width: 150px; }
+[data-tv] .bug-live { font-size: .85rem; }
+[data-tv] .bug-name { font-size: 1.6rem; }
+
+/* topbar */
 [data-tv] .brand-name { font-size: 2rem; }
-[data-tv] .bigclock-next { font-size: 2.2rem; }
+[data-tv] .brand-sub { font-size: .8rem; }
+[data-tv] .health { font-size: .8rem; padding: 6px 14px; }
+[data-tv] .icon-btn { width: 56px; height: 56px; font-size: 1.4rem; }
 /* 10-foot: hide the dense header count stats; brand + health + actions remain. */
 [data-tv] .topbar .stats { display: none; }
+
+/* league chips + stage */
+[data-tv] .league-chip { font-size: 1.3rem; padding: 13px 26px; }
+[data-tv] .grid { grid-template-columns: repeat(auto-fill, minmax(360px, 1fr)); gap: 16px; }
+[data-tv] .game { min-height: 200px; padding: 20px 22px 18px; }
+[data-tv] .gt .who, [data-tv] .gt .sc { font-size: 2rem; }
+[data-tv] .badge { font-size: 1rem; padding: 4px 12px; }
+[data-tv] .league-tag { font-size: .8rem; }
+[data-tv] .ch { font-size: .95rem; padding: 3px 9px; }
+[data-tv] .when { font-size: .8rem; }
+[data-tv] .fav-star { width: 48px; height: 48px; font-size: 1.3rem; }
+[data-tv] .watch-mini { width: 48px; height: 48px; font-size: 1.1rem; }
+
+/* hero — tame the huge numerals so they relate to the cards below */
+[data-tv] .hero-meta { font-size: .8rem; }
+[data-tv] .abbr { font-size: 2.4rem; }
+[data-tv] .score { font-size: 2.8rem; }
+[data-tv] .pill { font-size: 1rem; padding: 5px 11px; }
+
+/* drawer */
+[data-tv] .drawer-panel { width: min(820px, 96vw); }
+[data-tv] .drawer h2 { font-size: 2rem; }
+[data-tv] .kicker { font-size: .8rem; }
+[data-tv] .drawer .block h3 { font-size: 1.3rem; }
+[data-tv] .hint, [data-tv] .fineprint { font-size: .95rem; }
+[data-tv] .drawer input, [data-tv] .drawer select { font-size: 1.1rem; padding: 14px; }
+[data-tv] .check { font-size: 1.1rem; }
+[data-tv] .check input { width: 26px; height: 26px; margin-top: 1px; }
+[data-tv] .feed-list span { font-size: .85rem; }
+[data-tv] .feed-list b { font-size: 1.1rem; }
+[data-tv] .pair-url { font-size: 1rem; }
+[data-tv] .speed-val { font-size: 1.1rem; }
+
+/* updates panel */
+[data-tv] .update-label, [data-tv] .update-note { font-size: .95rem; }
+[data-tv] .update-value { font-size: 1.2rem; }
+[data-tv] .update-banner-title { font-size: 1.3rem; }
+
+/* empty state */
+[data-tv] .empty p { font-size: .95rem; }
+
+/* drawer: left rail + right content pane (standard 10-foot settings layout) */
+[data-tv] .drawer-body {
+  display: grid;
+  grid-template-columns: 224px minmax(0, 1fr);
+  gap: 24px;
+  min-height: 0;
+}
+[data-tv] .drawer-rail {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 6px;
+  overflow-x: visible;
+  overflow-y: auto;
+  margin-bottom: 0;
+  padding-right: 6px;
+}
+[data-tv] .rail-item {
+  justify-content: flex-start;
+  border-radius: 14px;
+  padding: 15px 16px;
+  font-size: 1.1rem;
+  font-family: var(--ui);
+}
+[data-tv] .rail-ic { font-size: 1.25rem; }
+[data-tv] .drawer-sections { overflow-y: auto; min-height: 0; padding-right: 8px; }
+[data-tv] .drawer-section.is-active { padding-bottom: 4px; }
+
+/* watch apps */
+[data-tv] .watch-row { grid-template-columns: 130px 1fr; }
+[data-tv] .watch-league { font-size: 1.3rem; }
+[data-tv] .watch-btn { padding: 16px 28px; font-size: 1.3rem; }
+
+/* controls — every square button is 56px, ghost text one size */
+[data-tv] .row-actions .ghost { min-width: 56px; height: 56px; font-size: 1.1rem; }
+[data-tv] .stepper .ghost { width: 56px; height: 56px; font-size: 1.5rem; }
+[data-tv] .ghost { padding: 12px 18px; font-size: 1.1rem; }
+[data-tv] .team-chip { font-size: 1.1rem; padding: 10px 18px; }
+
+/* ticker-only mode */
+[data-tv] .bigclock-next { font-size: 2rem; }
+
+/* focus: one ring everywhere, sized for the larger UI */
+[data-tv] .focusable:focus { outline: 6px solid var(--line); outline-offset: 4px; }
 
 /* ---- settings rows: steppers & reorder (AUDIT E2/D7) ------------------ */
 .stepper {
@@ -644,3 +794,143 @@ input, select {
 /* `hidden` must always win over component display rules (the drawer is
    `display:flex` and used to show through its hidden attribute — P0 fix). */
 [hidden] { display: none; }
+
+/* ========================================================================
+   UI polish pass — typography, tactile states, scrollbars, broadcast fades.
+   Kept purely cosmetic: no selector names are changed, nothing re-laid-out.
+   ======================================================================== */
+
+html {
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+::selection { background: var(--line); color: #041018; }
+
+/* ---- tactile buttons + transitions ------------------------------------ */
+.icon-btn, .primary, .ghost, .league-chip, .rail-item, .fav-star,
+.watch-btn, .watch-mini, .team-chip, .row-actions .ghost, .stepper .ghost {
+  transition: border-color .16s ease, color .16s ease, background .16s ease,
+    transform .1s ease, box-shadow .16s ease, filter .16s ease;
+}
+.icon-btn:active, .primary:active, .ghost:active, .league-chip:active,
+.rail-item:active, .fav-star:active, .watch-btn:active, .watch-mini:active,
+.team-chip:active, .row-actions .ghost:active { transform: scale(.96); }
+.primary:active { filter: brightness(.95); }
+.league-chip[aria-pressed="true"] { box-shadow: 0 0 0 1px var(--line); }
+
+/* ---- inputs: focus + accent colour ------------------------------------ */
+input, select { transition: border-color .16s ease, box-shadow .16s ease; }
+input::placeholder { color: var(--faint); }
+input:focus-visible, select:focus-visible {
+  outline: none;
+  border-color: var(--line);
+  box-shadow: 0 0 0 3px var(--line-dim);
+}
+input[type="checkbox"], input[type="radio"], input[type="range"] { accent-color: var(--line); }
+[data-tv] input:focus, [data-tv] select:focus {
+  outline: none;
+  border-color: var(--line);
+  box-shadow: 0 0 0 3px var(--line-dim);
+}
+
+/* ---- scrollbars (desktop web; TVs have no pointer wheel) -------------- */
+.stage, .drawer-panel, .drawer-sections, .team-picker, .drawer-rail {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255,255,255,.18) transparent;
+}
+.stage::-webkit-scrollbar, .drawer-panel::-webkit-scrollbar,
+.drawer-sections::-webkit-scrollbar, .team-picker::-webkit-scrollbar,
+.drawer-rail::-webkit-scrollbar { width: 8px; height: 8px; }
+.stage::-webkit-scrollbar-thumb, .drawer-panel::-webkit-scrollbar-thumb,
+.drawer-sections::-webkit-scrollbar-thumb, .team-picker::-webkit-scrollbar-thumb,
+.drawer-rail::-webkit-scrollbar-thumb {
+  background: rgba(255,255,255,.14); border-radius: 999px;
+}
+.stage::-webkit-scrollbar-thumb:hover { background: rgba(255,255,255,.26); }
+
+/* ---- cards ------------------------------------------------------------- */
+.game { box-shadow: 0 1px 0 rgba(0,0,0,.25); }
+.game:hover { box-shadow: 0 10px 30px rgba(0,0,0,.35); }
+.gt .who, .team-name, .abbr {
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.badge.live { box-shadow: 0 0 14px rgba(255,45,85,.35); }
+.hero-card { box-shadow: 0 18px 50px rgba(0,0,0,.35); }
+.stat b, .score, .chyron-clock { font-variant-numeric: tabular-nums; }
+
+/* ---- chyron: edge fades so the crawl melts into the bug + clock -------- */
+.crawl-mask { position: relative; }
+.crawl-mask::before, .crawl-mask::after {
+  content: ""; position: absolute; top: 0; bottom: 0; width: 46px;
+  z-index: 1; pointer-events: none;
+}
+.crawl-mask::before { left: 0; background: linear-gradient(90deg, #05070a, rgba(5,7,10,0)); }
+.crawl-mask::after  { right: 0; background: linear-gradient(270deg, #05070a, rgba(5,7,10,0)); }
+.health { transition: color .3s ease, border-color .3s ease; }
+
+/* ---- drawer ------------------------------------------------------------- */
+.drawer-panel { box-shadow: -28px 0 80px rgba(0,0,0,.55); }
+.drawer-panel { animation: drawer-in .22s ease; }
+.drawer h2 { font-weight: 800; }
+.block h3 {
+  display: flex; align-items: center; gap: 8px;
+  letter-spacing: .12em; text-transform: uppercase; color: var(--muted);
+}
+.block h3::before {
+  content: ""; width: 3px; height: 1em; border-radius: 2px; background: var(--line);
+}
+.feed-list li:hover { border-color: var(--line); }
+.rail-item:active { transform: scale(.98); }
+
+/* ---- toast -------------------------------------------------------------- */
+.toast { box-shadow: 0 12px 40px rgba(0,0,0,.5); animation: toast-in .18s ease; }
+
+/* ---- big clock (ticker-only mode) --------------------------------------- */
+.bigclock-time { text-shadow: 0 0 48px rgba(0,212,255,.22); }
+
+/* ---- empty state --------------------------------------------------------- */
+.empty { margin: 0 auto; text-align: center; }
+.empty .primary { margin-top: 6px; }
+
+@keyframes drawer-in { from { transform: translateX(28px); opacity: .5; } to { transform: none; opacity: 1; } }
+@keyframes toast-in { from { transform: translate(-50%, 8px); opacity: 0; } to { transform: translate(-50%, 0); opacity: 1; } }
+@media (prefers-reduced-motion: reduce) {
+  .drawer-panel, .toast { animation: none; }
+  .icon-btn, .primary, .ghost, .league-chip, .rail-item, .fav-star,
+  .watch-btn, .watch-mini, .team-chip { transition: none; }
+}
+
+/* ========================================================================
+   Phone floating overlay (OverlayService.kt) — the same app with everything
+   except the chyron stripped out. The window itself is translucent and
+   touch-through; the strip needs enough ink to stay legible over any app.
+   ======================================================================== */
+[data-overlay] { background: transparent; }
+[data-overlay] body {
+  background: transparent;
+  background-image: none;
+}
+[data-overlay] .bootfallback,
+[data-overlay] .topbar,
+[data-overlay] .leagues,
+[data-overlay] .stage,
+[data-overlay] .drawer,
+[data-overlay] .toast { display: none !important; }
+[data-overlay] .app {
+  display: block;
+  height: 100%;
+  padding: 0;
+}
+[data-overlay] .chyron {
+  height: 100%;
+  border: 0;
+  box-shadow: none;
+  background: linear-gradient(180deg, rgba(5,7,10,.92), rgba(5,7,10,.82));
+}
+[data-overlay] .chyron-bug { min-width: 68px; padding: 0 12px; border-right-color: rgba(255,255,255,.12); }
+[data-overlay] .bug-name { font-size: 1.05rem; }
+[data-overlay] .bug-live { font-size: .58rem; }
+[data-overlay] .tick { font-size: 1.02rem; padding: 0 20px; gap: 8px; }
+[data-overlay] .tick::after { margin-left: 18px; }
+[data-overlay] .tick .k { font-size: .8rem; }
+[data-overlay] .chyron-clock { min-width: 76px; font-size: 1.05rem; }

--- a/ticker/public/index.html
+++ b/ticker/public/index.html
@@ -84,97 +84,131 @@
         <header class="drawer-head">
           <div>
             <div class="kicker">Setup</div>
-            <h2>Feeds &amp; ticker</h2>
+            <h2>Settings</h2>
           </div>
           <button class="icon-btn focusable" data-action="close-settings" aria-label="Close">✕</button>
         </header>
 
-        <section class="block">
-          <h3>Your RSS feeds</h3>
-          <p class="hint">Paste any RSS, Atom, or JSON listing. Channel-list apps, sports blogs, or a homemade XML file all work. Core Line never plays video — it only reads names and channels.</p>
-          <div class="feed-add">
-            <input class="focusable" id="feedUrl" type="url" placeholder="https://example.com/sports.xml" autocomplete="off" spellcheck="false">
-            <input class="focusable" id="feedLabel" type="text" placeholder="Label" maxlength="24">
-            <button class="primary focusable" data-action="add-feed">Add</button>
+        <div class="drawer-body">
+          <nav class="drawer-rail" id="drawerRail" aria-label="Settings sections">
+            <button class="rail-item focusable is-active" data-action="drawer-section" data-section="feeds" aria-pressed="true"><span class="rail-ic">📡</span> Feeds</button>
+            <button class="rail-item focusable" data-action="drawer-section" data-section="scoreboards" aria-pressed="false"><span class="rail-ic">🏆</span> Scoreboards</button>
+            <button class="rail-item focusable" data-action="drawer-section" data-section="ticker" aria-pressed="false"><span class="rail-ic">🎚️</span> Ticker &amp; display</button>
+            <button class="rail-item focusable" data-action="drawer-section" data-section="watch" aria-pressed="false"><span class="rail-ic">▶️</span> Watch apps</button>
+            <button class="rail-item focusable" data-action="drawer-section" data-section="updates" aria-pressed="false"><span class="rail-ic">⬇️</span> Updates</button>
+            <button class="rail-item focusable" data-action="drawer-section" data-section="about" aria-pressed="false"><span class="rail-ic">?</span> Help &amp; about</button>
+          </nav>
+
+          <div class="drawer-sections">
+            <section class="block drawer-section is-active" data-panel="feeds">
+              <h3>Your RSS feeds</h3>
+              <p class="hint">Paste any RSS, Atom, or JSON listing. Channel-list apps, sports blogs, or a homemade XML file all work. Core Line never plays video — it only reads names and channels.</p>
+              <div class="feed-add">
+                <input class="focusable" id="feedUrl" type="url" placeholder="https://example.com/sports.xml" autocomplete="off" spellcheck="false">
+                <input class="focusable" id="feedLabel" type="text" placeholder="Label" maxlength="24">
+                <button class="primary focusable" data-action="add-feed">Add</button>
+              </div>
+              <div class="pair" id="pairBox">
+                <button class="ghost focusable" data-action="pair-start" id="pairStart">Add from phone (same Wi-Fi)</button>
+                <div class="pair-card" id="pairCard" hidden>
+                  <p class="hint">On your phone, same Wi-Fi as this TV. Scan or open the address. Type the code. Do not type the RSS URL on the Stick.</p>
+                  <img class="pair-qr" id="pairQr" alt="QR to add a feed">
+                  <div class="pair-url" id="pairUrl"></div>
+                  <div class="pair-code" id="pairCode"></div>
+                  <button class="ghost focusable" data-action="pair-stop">Stop pairing</button>
+                </div>
+              </div>
+              <ul class="feed-list" id="feedList"></ul>
+              <label class="check">
+                <input class="focusable" type="checkbox" id="sampleFeed" checked>
+                <span>Include the bundled sample feed so the crawl is never empty</span>
+              </label>
+            </section>
+
+            <section class="block drawer-section" data-panel="scoreboards">
+              <h3>Scoreboards</h3>
+              <p class="hint">Checked leagues are fetched from public scoreboards and shown as their own tabs. Unchecked leagues are hidden but stay available to re-enable.</p>
+              <div class="chip-grid" id="leagueToggles"></div>
+            </section>
+
+            <section class="block drawer-section" data-panel="ticker">
+              <h3>Ticker &amp; display</h3>
+              <div class="split">
+                <label>Ticker speed
+                  <div class="stepper">
+                    <button class="ghost focusable" data-action="speed-down" aria-label="Slower">−</button>
+                    <input class="focusable" id="speed" type="range" min="20" max="120" value="52" aria-label="Ticker speed">
+                    <button class="ghost focusable" data-action="speed-up" aria-label="Faster">+</button>
+                  </div>
+                  <span class="speed-val" id="speedVal">52 px/s</span>
+                </label>
+                <label>Refresh every
+                  <select class="focusable" id="refreshSec">
+                    <option value="15">15 seconds</option>
+                    <option value="30">30 seconds</option>
+                    <option value="60" selected>1 minute</option>
+                    <option value="120">2 minutes</option>
+                    <option value="300">5 minutes</option>
+                    <option value="600">10 minutes</option>
+                  </select>
+                </label>
+                <label>Ticker position
+                  <select class="focusable" id="position">
+                    <option value="bottom" selected>Bottom</option>
+                    <option value="top">Top</option>
+                  </select>
+                </label>
+                <label>Theme
+                  <select class="focusable" id="theme">
+                    <option value="core">Core midnight</option>
+                    <option value="broadcast">Broadcast red</option>
+                    <option value="stadium">Stadium night</option>
+                    <option value="mono">High contrast</option>
+                  </select>
+                </label>
+                <label>Clock
+                  <select class="focusable" id="clockFmt">
+                    <option value="12">12-hour</option>
+                    <option value="24">24-hour</option>
+                  </select>
+                </label>
+              </div>
+              <div class="fav-block">
+                <label>Favorite teams
+                  <input class="focusable" id="favorites" type="text" placeholder="TOR, LAL, KC, ARS">
+                </label>
+                <div class="team-picker" id="teamPicker" role="group" aria-label="Teams in this slate"></div>
+              </div>
+              <div class="split checks">
+                <label class="check"><input class="focusable" type="checkbox" id="showFinals" checked><span>Show finals</span></label>
+                <label class="check"><input class="focusable" type="checkbox" id="wakeLock" checked><span>Keep screen awake</span></label>
+              </div>
+              <div class="overlay-block" id="overlayBlock" hidden>
+                <label class="check"><input class="focusable" type="checkbox" id="overlayEnabled"><span>Floating ticker over other apps (phone)</span></label>
+                <p class="hint small">Draws the crawl on top of every app, edge to edge. Android TV doesn’t allow overlays, so this is phone/tablet only. Stop it from the notification or untick this box.</p>
+              </div>
+            </section>
+
+            <section class="block drawer-section" data-panel="watch">
+              <h3>Open games in other apps</h3>
+              <p class="hint">Assign an installed app to each league. Pressing <b>▶ Watch</b> on a game (or the W key) opens that app so you can watch; “Web browser” opens the game page on ESPN instead.</p>
+              <div class="watch-list" id="watchList"></div>
+              <p class="hint small" id="watchAppsStatus"></p>
+            </section>
+
+            <section class="block drawer-section" data-panel="updates">
+              <h3>Updates</h3>
+              <p class="hint">Core Line updates come from the GitHub release feed. On a TV, download the new APK and the system installer takes over — your settings are kept.</p>
+              <div id="updatePanel" role="status" aria-live="polite"></div>
+            </section>
+
+            <section class="block drawer-section" data-panel="about">
+              <h3>Help &amp; about</h3>
+              <p class="fineprint">D-pad: move · OK: select · Air mouse: point &amp; click · S: settings · T: ticker · R: refresh · W: watch · F: fullscreen. This is a TV guide, not a player.</p>
+              <p class="hint">Core Line reads public scoreboards (ESPN, NHL, MLB) and your own RSS/JSON feeds. It never plays video — the Watch feature hands a game off to the app you choose.</p>
+            </section>
           </div>
-          <div class="pair" id="pairBox">
-            <button class="ghost focusable" data-action="pair-start" id="pairStart">Add from phone (same Wi-Fi)</button>
-            <div class="pair-card" id="pairCard" hidden>
-              <p class="hint">On your phone, same Wi-Fi as this TV. Scan or open the address. Type the code. Do not type the RSS URL on the Stick.</p>
-              <img class="pair-qr" id="pairQr" alt="QR to add a feed">
-              <div class="pair-url" id="pairUrl"></div>
-              <div class="pair-code" id="pairCode"></div>
-              <button class="ghost focusable" data-action="pair-stop">Stop pairing</button>
-            </div>
-          </div>
-          <ul class="feed-list" id="feedList"></ul>
-          <label class="check">
-            <input class="focusable" type="checkbox" id="sampleFeed" checked>
-            <span>Include the bundled sample feed so the crawl is never empty</span>
-          </label>
-        </section>
-
-        <section class="block">
-          <h3>Scoreboards</h3>
-          <div class="chip-grid" id="leagueToggles"></div>
-        </section>
-
-        <section class="block split">
-          <label>Ticker speed
-            <div class="stepper">
-              <button class="ghost focusable" data-action="speed-down" aria-label="Slower">−</button>
-              <input class="focusable" id="speed" type="range" min="20" max="120" value="52" aria-label="Ticker speed">
-              <button class="ghost focusable" data-action="speed-up" aria-label="Faster">+</button>
-            </div>
-            <span class="speed-val" id="speedVal">52 px/s</span>
-          </label>
-          <div class="fav-block">
-            <label>Favorite teams
-              <input class="focusable" id="favorites" type="text" placeholder="TOR, LAL, KC, ARS">
-            </label>
-            <div class="team-picker" id="teamPicker" role="group" aria-label="Teams in this slate"></div>
-          </div>
-        </section>
-
-        <section class="block split">
-          <label>Refresh every
-            <select class="focusable" id="refreshSec">
-              <option value="15">15 seconds</option>
-              <option value="30">30 seconds</option>
-              <option value="60" selected>1 minute</option>
-              <option value="120">2 minutes</option>
-              <option value="300">5 minutes</option>
-              <option value="600">10 minutes</option>
-            </select>
-          </label>
-          <label>Ticker position
-            <select class="focusable" id="position">
-              <option value="bottom" selected>Bottom</option>
-              <option value="top">Top</option>
-            </select>
-          </label>
-        </section>
-
-        <section class="block split">
-          <label class="check"><input class="focusable" type="checkbox" id="showFinals" checked><span>Show finals</span></label>
-          <label class="check"><input class="focusable" type="checkbox" id="wakeLock" checked><span>Keep screen awake</span></label>
-          <label>Theme
-            <select class="focusable" id="theme">
-              <option value="core">Core midnight</option>
-              <option value="broadcast">Broadcast red</option>
-              <option value="stadium">Stadium night</option>
-              <option value="mono">High contrast</option>
-            </select>
-          </label>
-          <label>Clock
-            <select class="focusable" id="clockFmt">
-              <option value="12">12-hour</option>
-              <option value="24">24-hour</option>
-            </select>
-          </label>
-        </section>
-
-        <p class="fineprint">D-pad: move · OK: select · Air mouse: point &amp; click · S: settings · T: ticker · R: refresh · F: fullscreen. This is a TV guide, not a player.</p>
+        </div>
       </div>
     </aside>
 

--- a/ticker/public/js/app.js
+++ b/ticker/public/js/app.js
@@ -1,5 +1,7 @@
 import { toTickerText, parseFeed } from '/lib/parser.mjs';
 import { LEAGUES, LEAGUE_LABELS, SPORT_GROUPS, compareEvents, buildDemoSlate, mergeEvents } from '/lib/scoreboard.mjs';
+import { WATCH_WEB, sortAppsForPicker, espnWebUrl, watchChoiceFor } from '/lib/watch.mjs';
+import { updateStatus as buildUpdateStatus } from '/lib/version.mjs';
 import { buildClientSlate, isNativeShell, hydrateClientSlateRegistry, getClientSlateRegistry } from '/lib/client-slate.mjs';
 import { isSafeFeedUrl } from '/lib/ssrf.mjs';
 import { loadState, saveState, cacheSlate, readCachedSlate, REFRESH_CHOICES, SPEED_MIN, SPEED_MAX } from './state.js';
@@ -11,6 +13,7 @@ import { startWatchdog } from './watchdog.js';
 const params = new URLSearchParams(location.search);
 if (params.get('native') === '1') globalThis.CORELINE_NATIVE = true;
 if (params.get('tv') === '1') globalThis.CORELINE_TV = true;
+if (params.get('overlay') === '1') globalThis.CORELINE_OVERLAY = true;
 
 // Boot guard for ancient WebViews (AUDIT.md A1): module support detected by
 // the fact that this file runs at all.
@@ -38,6 +41,12 @@ let refreshGen = 0;
 let refreshing = false;
 let pairTimer = null;
 let lastFocusBeforeDrawer = null;
+let installedApps = [];
+let updateInfo = null;
+let updateChecking = false;
+
+const UPDATE_RELEASES_URL = 'https://api.github.com/repos/brevityA/CoreBuildsApps/releases?per_page=30';
+const UPDATE_APK_NAME = 'coreline-release.apk';
 let lastHealth = { demo: false, degraded: 0, stale: 0 };
 
 let ticker = null;
@@ -46,11 +55,12 @@ init();
 
 async function init() {
   document.documentElement.toggleAttribute('data-tv', Boolean(globalThis.CORELINE_TV));
+  document.documentElement.toggleAttribute('data-overlay', Boolean(globalThis.CORELINE_OVERLAY));
   document.documentElement.dataset.position = state.position;
   hydrateClientSlateRegistry();
   applyChrome();
   bind();
-  initTvNav(document.getElementById('app'));
+  if (!globalThis.CORELINE_OVERLAY) initTvNav(document.getElementById('app'));
 
   ticker = new Ticker({
     track: $('crawl'),
@@ -91,6 +101,7 @@ async function init() {
 
   await refresh();
   armRefreshTimer();
+  if (isNativeShell() && !globalThis.CORELINE_OVERLAY) loadInstalledApps();
   if ('serviceWorker' in navigator && !isNativeShell()) {
     navigator.serviceWorker.register('./sw.js').catch(() => {});
   }
@@ -125,6 +136,10 @@ function bind() {
     if (action === 'speed-down') nudgeSpeed(-4);
     if (action === 'toggle-team') toggleTeam(btn.dataset.abbr);
     if (action === 'toggle-card-fav') toggleCardFav(btn.dataset.id);
+    if (action === 'watch') watchEventById(btn.dataset.id);
+    if (action === 'drawer-section') activateDrawerSection(btn.dataset.section);
+    if (action === 'check-updates') checkForUpdates(true);
+    if (action === 'install-update') installUpdateFlow();
     if (action === 'filter') {
       state.leagueFilter = btn.dataset.league;
       persist();
@@ -177,17 +192,42 @@ function bind() {
     document.documentElement.dataset.position = state.position;
   });
 
+  $('overlayEnabled')?.addEventListener('change', () => {
+    const on = $('overlayEnabled').checked;
+    if (on) {
+      const started = nativeBridge()?.startOverlay?.() === true;
+      $('overlayEnabled').checked = nativeBridge()?.overlayActive?.() === true;
+      if (!started) toast('Allow “display over other apps” for Core Line, then retick');
+    } else {
+      nativeBridge()?.stopOverlay?.();
+    }
+    state.overlay = Boolean(nativeBridge()?.overlayActive?.());
+    persist();
+  });
+
   window.addEventListener('keydown', (event) => {
     if (event.target.matches('input, textarea, select')) return;
     const key = event.key.toLowerCase();
     if (key === 's') openDrawer(true);
     if (key === 't') toggleMode();
     if (key === 'r') refresh(true);
+    if (key === 'w') {
+      const featured = events.find((e) => e.status === 'live' && e.away && e.home)
+        || events.find((e) => e.status === 'upcoming' && e.away && e.home);
+      if (featured) watchEventById(featured.id);
+    }
     if (key === 'f') document.documentElement.requestFullscreen?.().catch(() => {});
   });
 
   $('drawer').addEventListener('click', (event) => {
     if (event.target.id === 'drawer') openDrawer(false);
+  });
+
+  // TV sidebar behaviour: focusing a rail item selects its section, so
+  // D-pad up/down through the rail shows each section as you pass it.
+  $('drawerRail').addEventListener('focusin', (event) => {
+    const btn = event.target.closest('[data-section]');
+    if (btn) activateDrawerSection(btn.dataset.section);
   });
 }
 
@@ -249,7 +289,13 @@ function applyChrome() {
   renderLeagueToggles();
   renderFeeds();
   if ($('pairBox')) $('pairBox').hidden = !isNativeShell();
-  syncWakeLock();
+  if ($('overlayBlock')) {
+    $('overlayBlock').hidden = !(isNativeShell() && !globalThis.CORELINE_TV);
+  }
+  if ($('overlayEnabled')) {
+    $('overlayEnabled').checked = Boolean(nativeBridge()?.overlayActive?.());
+  }
+  if (!globalThis.CORELINE_OVERLAY) syncWakeLock();
 }
 
 function persist() {
@@ -262,10 +308,15 @@ function openDrawer(open) {
   if (open) {
     lastFocusBeforeDrawer = document.activeElement;
     document.body.classList.add('drawer-open');
-    const closeBtn = drawer.querySelector('[data-action="close-settings"]');
-    const first = drawer.querySelector('.focusable');
-    if (globalThis.CORELINE_TV) (closeBtn || first)?.focus();
-    else $('feedUrl').focus();
+    const rail = $('drawerRail');
+    const firstRail = rail?.querySelector('.rail-item');
+    if (globalThis.CORELINE_TV) {
+      activateDrawerSection(firstRail?.dataset.section || 'feeds');
+      (firstRail || drawer.querySelector('[data-action="close-settings"]'))?.focus();
+    } else {
+      activateDrawerSection('feeds');
+      $('feedUrl').focus();
+    }
   } else {
     document.body.classList.remove('drawer-open');
     stopPair();
@@ -273,6 +324,146 @@ function openDrawer(open) {
       lastFocusBeforeDrawer.focus();
     }
   }
+}
+
+function activateDrawerSection(name) {
+  document.querySelectorAll('#drawerRail .rail-item').forEach((b) => {
+    b.classList.toggle('is-active', b.dataset.section === name);
+    b.setAttribute('aria-pressed', b.dataset.section === name ? 'true' : 'false');
+  });
+  document.querySelectorAll('.drawer-section').forEach((s) => {
+    s.classList.toggle('is-active', s.dataset.panel === name);
+  });
+  if (name === 'watch') renderWatchApps();
+  if (name === 'updates') {
+    renderUpdates();
+    if (!updateInfo && !updateChecking) checkForUpdates(false);
+  }
+}
+
+function currentVersion() {
+  try {
+    const v = nativeBridge()?.getVersion?.();
+    return typeof v === 'string' && v ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+/** GitHub release bodies arrive as markdown; flatten to plain panel text. */
+function cleanNotes(body) {
+  return String(body || '')
+    .replace(/^#+\s*/gm, '')
+    .replace(/^\s*[-*]\s+/gm, '· ')
+    .replace(/[*_`~]/g, '')
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+    .replace(/\s{2,}/g, ' ')
+    .trim();
+}
+
+function renderUpdates() {
+  const el = $('updatePanel');
+  if (!el) return;
+  const native = isNativeShell();
+  const current = currentVersion();
+  const rows = [];
+
+  if (current) {
+    rows.push(`<div class="update-row"><span class="update-label">Current version</span><span class="update-value">${esc(current)}</span></div>`);
+  } else {
+    rows.push(`<div class="update-row"><span class="update-label">Build</span><span class="update-value">${native ? 'TV app' : 'Web build'}</span></div>`);
+  }
+
+  if (updateChecking) {
+    rows.push(`<div class="update-note checking">Checking for updates…</div>`);
+  } else if (updateInfo && updateInfo.ok) {
+    if (updateInfo.newer) {
+      rows.push(`<div class="update-banner">
+        <div class="update-banner-title">Update ${esc(updateInfo.latest)} is available</div>
+        ${updateInfo.notes ? `<div class="update-notes">${esc(cleanNotes(updateInfo.notes).slice(0, 300))}</div>` : ''}
+      </div>`);
+      if (native) {
+        rows.push(`<button class="primary focusable" data-action="install-update">Download &amp; install ${esc(updateInfo.latest)}</button>`);
+      } else {
+        rows.push(`<div class="update-note">Updates install on the Android TV app (Settings → Updates).</div>`);
+      }
+    } else {
+      rows.push(`<div class="update-note ok">You’re up to date${updateInfo.latest ? ` (latest ${esc(updateInfo.latest)})` : ''}.</div>`);
+    }
+  } else if (updateInfo && !updateInfo.ok) {
+    rows.push(`<div class="update-note error">${esc(updateInfo.error || 'Update check failed.')}</div>`);
+  } else {
+    rows.push(`<div class="update-note">Not checked yet.</div>`);
+  }
+
+  rows.push(`<button class="ghost focusable" data-action="check-updates" ${updateChecking ? 'disabled' : ''}>Check for updates</button>`);
+  el.innerHTML = rows.join('');
+}
+
+async function checkForUpdates(manual = false) {
+  if (updateChecking) return;
+  updateChecking = true;
+  renderUpdates();
+  try {
+    const url = isNativeShell()
+      ? `/api/proxy?url=${encodeURIComponent(UPDATE_RELEASES_URL)}`
+      : UPDATE_RELEASES_URL;
+    const res = await fetch(url, { headers: { Accept: 'application/json' }, signal: AbortSignal.timeout(20000) });
+    if (!res.ok) throw new Error('http ' + res.status);
+    const releases = await res.json();
+    updateInfo = buildUpdateStatus(releases, currentVersion() || '0', UPDATE_APK_NAME);
+  } catch (err) {
+    updateInfo = { ok: false, error: 'Could not reach the update server' };
+  }
+  updateChecking = false;
+  renderUpdates();
+  if (manual) {
+    toast(updateInfo?.newer ? 'Update available' : updateInfo?.ok ? 'You are up to date' : 'Update check failed');
+  }
+}
+
+function installUpdateFlow() {
+  const url = updateInfo?.apkUrl;
+  if (!url) return;
+  const bridge = nativeBridge();
+  if (bridge?.installUpdate) {
+    try {
+      if (bridge.installUpdate(url)) {
+        toast('Downloading update — the installer opens when ready');
+        return;
+      }
+    } catch { /* fall back to browser */ }
+  }
+  if (bridge?.openUrl) {
+    try {
+      bridge.openUrl(`https://github.com/brevityA/CoreBuildsApps/releases/tag/${encodeURIComponent(updateInfo.tag || 'coreline-v' + updateInfo.latest)}`);
+      return;
+    } catch { /* ignore */ }
+  }
+  toast('Could not start the update');
+}
+
+/** Open the app (or web page) assigned to a game's league. */
+async function watchEventById(id) {
+  const ev = events.find((e) => e.id === id);
+  if (!ev) return;
+  const choice = watchChoiceFor(state.watchApps, ev.league);
+  const url = espnWebUrl(ev);
+  const bridge = nativeBridge();
+  if (choice !== WATCH_WEB && bridge?.openApp) {
+    try {
+      const ok = bridge.openApp(choice);
+      toast(ok ? 'Opening game in app…' : 'Could not open that app');
+      return;
+    } catch {
+      /* fall through to web */
+    }
+  }
+  if (bridge?.openUrl) {
+    try { bridge.openUrl(url); return; } catch { /* ignore */ }
+  }
+  try { window.open(url, '_blank', 'noopener'); } catch { /* ignore */ }
+  toast('Opening in browser');
 }
 
 function toggleMode() {
@@ -583,6 +774,52 @@ function toggleTeam(abbr) {
   if (chip) chip.focus();
 }
 
+function renderWatchApps() {
+  const el = $('watchList');
+  if (!el) return;
+  const leagues = state.leagues.length ? state.leagues : Object.keys(LEAGUES);
+  el.innerHTML = leagues.map((id) => {
+    const league = LEAGUES[id];
+    if (!league) return '';
+    const choice = watchChoiceFor(state.watchApps, league.label);
+    const opts = [
+      `<option value="${WATCH_WEB}" ${choice === WATCH_WEB ? 'selected' : ''}>Web browser</option>`,
+      ...installedApps.map((a) =>
+        `<option value="${esc(a.pkg)}" ${choice === a.pkg ? 'selected' : ''}>${esc(a.label)}</option>`),
+    ].join('');
+    return `
+      <div class="watch-row">
+        <span class="watch-league" style="--acc:${esc(league.accent)}">${league.label}</span>
+        <select class="focusable" data-watch-league="${id}" aria-label="App to open ${league.label} games">${opts}</select>
+      </div>`;
+  }).join('') || '<p class="hint">Enable leagues under Scoreboards to assign watch apps.</p>';
+  el.querySelectorAll('select').forEach((s) => {
+    s.addEventListener('change', () => {
+      state.watchApps[s.dataset.watchLeague] = s.value;
+      persist();
+    });
+  });
+  const status = $('watchAppsStatus');
+  if (status) {
+    status.textContent = installedApps.length
+      ? `Detected ${installedApps.length} installed apps on this device.`
+      : 'App list loads from the TV shell — install apps like ESPN, Fox Sports, or DAZN to pick them here.';
+  }
+}
+
+async function loadInstalledApps() {
+  try {
+    const raw = nativeBridge()?.listLaunchableApps?.();
+    if (!raw) return;
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return;
+    installedApps = sortAppsForPicker(parsed);
+    renderWatchApps();
+  } catch {
+    /* non-native (web) has no app list — keep Web browser only */
+  }
+}
+
 function cardFavTeams(ev) {
   return [ev.away?.abbr, ev.home?.abbr].filter(Boolean).map((s) => String(s).toUpperCase());
 }
@@ -707,6 +944,7 @@ function renderHero(list) {
       </div>
       <div class="hero-side">
         <div class="pills">${(featured.channels || []).map((c) => `<span class="pill">${esc(c)}</span>`).join('')}</div>
+        <button class="watch-btn focusable" data-action="watch" data-id="${esc(featured.id)}">▶ Watch</button>
         <div class="when">${esc(featured.venue || featured.feed || '')}</div>
       </div>
     </article>
@@ -746,6 +984,7 @@ function gameCard(ev) {
         <div class="game-top-right">
           <span class="badge ${badge}">${esc(label)}</span>
           <button class="fav-star focusable ${favOn ? 'on' : ''}" data-action="toggle-card-fav" data-id="${esc(ev.id)}" aria-label="${favOn ? 'Unfavorite' : 'Favorite'} these teams" aria-pressed="${favOn}">★</button>
+          <button class="watch-mini focusable" data-action="watch" data-id="${esc(ev.id)}" aria-label="Watch in app" title="Watch in app">▶</button>
         </div>
       </div>
       <div class="game-teams">

--- a/ticker/public/js/state.js
+++ b/ticker/public/js/state.js
@@ -20,6 +20,8 @@ export const DEFAULTS = {
   leagueFilter: 'ALL',
   refreshSec: 60,
   position: 'bottom',
+  watchApps: {},
+  overlay: false,
 };
 
 /**
@@ -46,6 +48,7 @@ export function sanitizeState(raw) {
   out.sampleFeed = Boolean(out.sampleFeed);
   out.showFinals = Boolean(out.showFinals);
   out.wakeLock = Boolean(out.wakeLock);
+  out.overlay = Boolean(out.overlay);
 
   out.speed = clampInt(out.speed, SPEED_MIN, SPEED_MAX, DEFAULTS.speed);
   out.refreshSec = REFRESH_CHOICES.includes(Number(out.refreshSec)) ? Number(out.refreshSec) : DEFAULTS.refreshSec;
@@ -56,6 +59,16 @@ export function sanitizeState(raw) {
   out.mode = out.mode === 'crawl' ? 'crawl' : 'board';
   out.theme = ['core', 'broadcast', 'stadium', 'mono'].includes(out.theme) ? out.theme : 'core';
   out.leagueFilter = typeof out.leagueFilter === 'string' ? out.leagueFilter : 'ALL';
+
+  // watchApps: leagueId → installed app package id (or the string 'web').
+  if (!out.watchApps || typeof out.watchApps !== 'object' || Array.isArray(out.watchApps)) {
+    out.watchApps = {};
+  }
+  out.watchApps = Object.fromEntries(
+    Object.entries(out.watchApps)
+      .filter(([k, v]) => typeof k === 'string' && typeof v === 'string')
+      .map(([k, v]) => [k, v.slice(0, 200)]),
+  );
 
   return out;
 }

--- a/ticker/public/js/tv.js
+++ b/ticker/public/js/tv.js
@@ -27,6 +27,9 @@ export function initTvNav(root) {
     if (next) {
       event.preventDefault();
       next.focus();
+      // Keep the focused item fully visible (grid rows below the fold, the
+      // horizontally scrolling filter row, and the drawer sections).
+      try { next.scrollIntoView({ block: 'nearest', inline: 'nearest' }); } catch { /* older WebView */ }
     }
   };
   window.addEventListener('keydown', onKey);
@@ -50,21 +53,30 @@ function nearest(current, dir) {
   });
   if (!nodes.length) return null;
   if (!current || !nodes.includes(current)) return nodes[0];
+
   const a = box(current);
+  const horiz = dir === 'left' || dir === 'right';
+  const sign = dir === 'left' || dir === 'up' ? -1 : 1;
+
   let best = null;
   let bestScore = Infinity;
   for (const node of nodes) {
     if (node === current) continue;
     const b = box(node);
-    const dx = b.cx - a.cx;
-    const dy = b.cy - a.cy;
-    const aligned = Math.abs(dir === 'left' || dir === 'right' ? dy : dx);
-    if (dir === 'left' && dx >= -4) continue;
-    if (dir === 'right' && dx <= 4) continue;
-    if (dir === 'up' && dy >= -4) continue;
-    if (dir === 'down' && dy <= 4) continue;
-    const along = Math.abs(dir === 'left' || dir === 'right' ? dx : dy);
-    const score = along + aligned * 2.4;
+    const along = (horiz ? b.cx - a.cx : b.cy - a.cy) * sign;
+    if (along <= 4) continue; // candidate must lie in the pressed direction
+
+    // Cross-axis overlap: prefer the item directly above/below (or left/right
+    // in the same row) over a diagonal neighbour — "down means down".
+    const cross = horiz ? Math.abs(b.cy - a.cy) : Math.abs(b.cx - a.cx);
+    const overlap = horiz
+      ? Math.min(a.y2, b.y2) - Math.max(a.y1, b.y1)
+      : Math.min(a.x2, b.x2) - Math.max(a.x1, b.x1);
+    const minSpan = Math.min(horiz ? a.h : a.w, horiz ? b.h : b.w);
+    const aligned = overlap > minSpan * 0.35;
+
+    // Aligned candidates are strongly preferred; diagonal ones pay a penalty.
+    const score = aligned ? along + cross * 0.5 : along + cross * 2.4 + 1000;
     if (score < bestScore) {
       bestScore = score;
       best = node;
@@ -75,7 +87,11 @@ function nearest(current, dir) {
 
 function box(el) {
   const r = el.getBoundingClientRect();
-  return { cx: r.left + r.width / 2, cy: r.top + r.height / 2 };
+  return {
+    cx: r.left + r.width / 2, cy: r.top + r.height / 2,
+    x1: r.left, x2: r.right, y1: r.top, y2: r.bottom,
+    w: r.width, h: r.height,
+  };
 }
 
 function visible(el) {

--- a/ticker/tests/smoke-updates.mjs
+++ b/ticker/tests/smoke-updates.mjs
@@ -1,0 +1,134 @@
+// Headless smoke: web (desktop), mobile, TV, and the new Updates panel.
+import { chromium } from 'playwright-core';
+
+const BASE = 'http://127.0.0.1:8787';
+const bin = '/usr/bin/chromium';
+let failures = 0;
+
+function ok(cond, msg) {
+  console.log((cond ? 'PASS' : 'FAIL') + '  ' + msg);
+  if (!cond) failures++;
+}
+
+const browser = await chromium.launch({
+  executablePath: bin,
+  args: ['--no-sandbox', '--disable-dev-shm-usage'],
+});
+
+async function open(path, viewport) {
+  const page = await browser.newPage({ viewport });
+  const errors = [];
+  page.on('pageerror', (e) => errors.push(String(e)));
+  page.on('console', (m) => { if (m.type() === 'error') errors.push(m.text()); });
+  await page.goto(BASE + path, { waitUntil: 'networkidle' });
+  return { page, errors };
+}
+
+// ---- 1. Desktop web renders scoreboard + chyron --------------------------
+{
+  const { page, errors } = await open('/', { width: 1440, height: 900 });
+  await page.waitForSelector('.game', { timeout: 15000 });
+  const games = await page.locator('.game').count();
+  ok(games > 0, `desktop: ${games} game cards render`);
+  ok(await page.locator('.chyron').count() === 1, 'desktop: chyron present');
+  ok(errors.length === 0, `desktop: no page errors (${errors.join(' | ').slice(0, 140) || 'none'})`);
+  await page.close();
+}
+
+// ---- 2. Mobile viewport ---------------------------------------------------
+{
+  const { page, errors } = await open('/', { width: 390, height: 844 });
+  await page.waitForSelector('.game', { timeout: 15000 });
+  ok(await page.locator('.game').count() > 0, 'mobile: cards render at 390px');
+  ok(errors.length === 0, 'mobile: no page errors');
+  await page.close();
+}
+
+// ---- 3. TV mode -----------------------------------------------------------
+{
+  const { page, errors } = await open('/?tv=1', { width: 1920, height: 1080 });
+  await page.waitForSelector('.game', { timeout: 15000 });
+  const isTv = await page.evaluate(() => document.documentElement.hasAttribute('data-tv'));
+  ok(isTv, 'tv: data-tv attribute set');
+  ok(errors.length === 0, 'tv: no page errors');
+
+  // TV consistency (the coherent 10-foot ladder): same-role elements share a
+  // size, nothing is stranded tiny (micro ≥16px) or blown out, and no card
+  // text overflows its column.
+  const tv = await page.evaluate(() => {
+    const fs = (sel) => { const el = document.querySelector(sel); return el ? parseFloat(getComputedStyle(el).fontSize) : null; };
+    const abbr = document.querySelector('.team-row .abbr');
+    return {
+      health: fs('.health'), brandSub: fs('.brand-sub'), when: fs('.when'),
+      leagueTag: fs('.league-tag'), tick: fs('.tick'), brandName: fs('.brand-name'),
+      who: fs('.gt .who'), abbr: fs('.abbr'), score: fs('.score'), hint: fs('.hint'),
+      abbrOverflow: abbr ? abbr.scrollWidth > abbr.clientWidth + 1 : false,
+    };
+  });
+  ok(tv.health >= 16, `tv: health pill not stranded tiny (${tv.health}px ≥ 16)`);
+  ok(tv.when >= 16, `tv: .when meta ≥ 16px (${tv.when})`);
+  ok(tv.tick >= 32, `tv: chyron tick large (${tv.tick}px)`);
+  ok(tv.who === tv.brandName, `tv: card team names and brand share one display size (${tv.who}px == ${tv.brandName}px)`);
+  ok(tv.abbr <= tv.score, `tv: hero numerals tame (abbr ${tv.abbr} ≤ score ${tv.score})`);
+  ok(!tv.abbrOverflow, 'tv: hero abbreviation does not overflow its column');
+  await page.close();
+}
+
+// ---- 4. Updates panel (web mode) ------------------------------------------
+{
+  const { page, errors } = await open('/', { width: 1440, height: 900 });
+  await page.waitForSelector('.game', { timeout: 15000 });
+  // Open settings drawer via its rail trigger.
+  await page.click('[data-action="settings"]');
+  await page.click('[data-action="drawer-section"][data-section="updates"]');
+  await page.waitForSelector('#updatePanel', { timeout: 5000 });
+  // Web build has no native version → should report an update is available.
+  await page.click('[data-action="check-updates"]');
+  await page.waitForFunction(() => {
+    const el = document.getElementById('updatePanel');
+    return el && /available|up to date|failed/i.test(el.textContent) && !/Checking/.test(el.textContent);
+  }, { timeout: 25000 });
+  const txt = await page.locator('#updatePanel').innerText();
+  ok(/Update \d+\.\d+\.\d+ is available/.test(txt), `updates: web build reports newer release — "${txt.replace(/\n/g, ' ').slice(0, 90)}…"`);
+  ok(/Android TV app/.test(txt), 'updates: web build tells user updates install on TV app');
+  ok(errors.length === 0, 'updates: no page errors');
+  await page.close();
+}
+
+// ---- 5. Phone floating overlay page (native=1&overlay=1) -----------------
+{
+  const { page, errors } = await open('/?native=1&overlay=1', { width: 390, height: 64 });
+  await page.waitForSelector('.chyron', { timeout: 15000 });
+  const isOverlay = await page.evaluate(() => document.documentElement.hasAttribute('data-overlay'));
+  ok(isOverlay, 'overlay: data-overlay attribute set');
+  const chrome = await page.evaluate(() => {
+    const vis = (sel) => {
+      const el = document.querySelector(sel);
+      if (!el) return 'missing';
+      const cs = getComputedStyle(el);
+      return cs.display === 'none' ? 'hidden' : 'visible';
+    };
+    return {
+      topbar: vis('.topbar'), stage: vis('.stage'), drawer: vis('.drawer'),
+      chyron: vis('.chyron'),
+      bodyBg: getComputedStyle(document.body).backgroundColor,
+    };
+  });
+  ok(chrome.topbar === 'hidden', `overlay: topbar hidden (${chrome.topbar})`);
+  ok(chrome.stage === 'hidden', `overlay: stage hidden (${chrome.stage})`);
+  ok(chrome.drawer === 'hidden', `overlay: drawer hidden (${chrome.drawer})`);
+  ok(chrome.chyron === 'visible', 'overlay: chyron visible');
+  ok(/rgba\(0, 0, 0, 0\)/.test(chrome.bodyBg), `overlay: body background transparent (${chrome.bodyBg})`);
+  await page.waitForSelector('.tick', { timeout: 15000 });
+  ok(await page.locator('.tick').count() > 0, 'overlay: tick items rendered');
+  // native=1 routes scoreboard/RSS fetches through /api/proxy, which only the
+  // Android shell serves — the Node dev server 404s it. Filter those expected
+  // resource-404s; anything else (JS exceptions, etc.) is a real failure.
+  const realErrors = errors.filter((e) => !/Failed to load resource|404/.test(e));
+  ok(realErrors.length === 0, `overlay: no real page errors (${realErrors.join(' | ').slice(0, 140) || 'none'})`);
+  await page.close();
+}
+
+await browser.close();
+console.log(failures === 0 ? '\nALL SMOKE CHECKS PASSED' : `\n${failures} CHECK(S) FAILED`);
+process.exit(failures === 0 ? 0 : 1);

--- a/ticker/tests/version.test.mjs
+++ b/ticker/tests/version.test.mjs
@@ -1,0 +1,54 @@
+/**
+ * lib/version.mjs — semver compare + GitHub coreline-v release parsing.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  compareVersions, versionFromCorelineTag, latestCorelineRelease, updateStatus,
+} from '../lib/version.mjs';
+
+test('compareVersions orders dotted versions numerically', () => {
+  assert.equal(compareVersions('1.2.0', '1.10.3'), -1);
+  assert.equal(compareVersions('1.10.3', '1.2.0'), 1);
+  assert.equal(compareVersions('1.2.0', '1.2.0'), 0);
+  assert.equal(compareVersions('1.2', '1.2.0'), 0);
+  assert.equal(compareVersions('2.0.0', '1.99.99'), 1);
+});
+
+test('versionFromCorelineTag strips the prefix, rejects others', () => {
+  assert.equal(versionFromCorelineTag('coreline-v1.1.0'), '1.1.0');
+  assert.equal(versionFromCorelineTag('coreline-v1.2.0-rc1'), '1.2.0-rc1');
+  assert.equal(versionFromCorelineTag('v1.8.0'), null); // iconpack tags
+  assert.equal(versionFromCorelineTag('doctor-v0.1.0'), null);
+});
+
+test('latestCorelineRelease picks the newest coreline tag and its apk asset', () => {
+  const releases = [
+    { tag_name: 'v1.8.0', assets: [{ name: 'app-release.apk', browser_download_url: 'https://x/app.apk' }] },
+    { tag_name: 'coreline-v1.0.2', assets: [{ name: 'coreline-release.apk', browser_download_url: 'https://x/old.apk' }] },
+    { tag_name: 'coreline-v1.2.0', assets: [{ name: 'coreline-release.apk', browser_download_url: 'https://x/new.apk' }] },
+    { tag_name: 'coreline-v1.1.0', assets: [{ name: 'coreline-release.apk', browser_download_url: 'https://x/mid.apk' }] },
+  ];
+  const best = latestCorelineRelease(releases);
+  assert.equal(best.version, '1.2.0');
+  assert.equal(best.apkUrl, 'https://x/new.apk');
+});
+
+test('latestCorelineRelease returns null without a matching asset', () => {
+  const releases = [{ tag_name: 'coreline-v1.2.0', assets: [] }];
+  const best = latestCorelineRelease(releases);
+  assert.equal(best.apkUrl, null);
+  assert.equal(best.version, '1.2.0');
+});
+
+test('updateStatus flags newer and survives empty/absent releases', () => {
+  const rels = [{ tag_name: 'coreline-v1.2.0', assets: [{ name: 'coreline-release.apk', browser_download_url: 'https://x/a.apk' }] }];
+  assert.equal(updateStatus(rels, '1.1.0').newer, true);
+  assert.equal(updateStatus(rels, '1.2.0').newer, false);
+  assert.equal(updateStatus(rels, '1.3.0').newer, false);
+  const none = updateStatus(null, '1.1.0');
+  assert.equal(none.ok, true);
+  assert.equal(none.newer, false);
+  assert.equal(none.latest, null);
+});

--- a/ticker/tests/watch.test.mjs
+++ b/ticker/tests/watch.test.mjs
@@ -1,0 +1,59 @@
+/**
+ * "Watch" integration (lib/watch.mjs) — assign an app per league, build the
+ * web fallback URL. Pure logic, no network.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  WATCH_WEB, SPORTS_APPS, sortAppsForPicker, leagueIdForLabel, espnWebUrl, watchChoiceFor,
+} from '../lib/watch.mjs';
+
+test('sortAppsForPicker puts curated sports apps first, dedupes, then alpha', () => {
+  const apps = [
+    { pkg: 'com.random.zoo', label: 'Zoo' },
+    { pkg: 'com.dazn', label: 'DAZN' },
+    { pkg: 'com.random.apple', label: 'Apple' },
+    { pkg: 'com.dazn', label: 'DAZN duplicate' },
+    null,
+    { pkg: '', label: 'empty pkg' },
+  ];
+  const out = sortAppsForPicker(apps);
+  const pkgs = out.map((a) => a.pkg);
+  assert.equal(pkgs[0], 'com.dazn'); // curated first
+  assert.equal(pkgs.filter((p) => p === 'com.dazn').length, 1); // deduped
+  assert.ok(!pkgs.includes('')); // empties dropped
+  const rest = pkgs.slice(1).sort();
+  assert.deepEqual(pkgs.slice(1), rest); // alpha after curated
+});
+
+test('SPORTS_APPS entries are well-formed and unique', () => {
+  const pkgs = SPORTS_APPS.map((a) => a.pkg);
+  assert.equal(new Set(pkgs).size, pkgs.length);
+  for (const a of SPORTS_APPS) assert.ok(a.pkg && a.label);
+});
+
+test('leagueIdForLabel maps display labels back to league ids', () => {
+  assert.equal(leagueIdForLabel('NFL'), 'nfl');
+  assert.equal(leagueIdForLabel('NCAAF'), 'ncaaf');
+  assert.equal(leagueIdForLabel('Basketball'), null); // sport group, not a league
+});
+
+test('espnWebUrl builds a canonical ESPN game URL for espn events', () => {
+  const url = espnWebUrl({ source: 'espn', league: 'NFL', id: '4012345' });
+  assert.equal(url, 'https://www.espn.com/nfl/game/_/gameId/4012345');
+});
+
+test('espnWebUrl falls back to a search URL for non-numeric ids', () => {
+  const url = espnWebUrl({ league: 'NHL', id: 'nhl-123', away: { name: 'Maple Leafs' }, home: { name: 'Canadiens' } });
+  assert.ok(url.startsWith('https://www.espn.com/search/_/q/'));
+  assert.ok(url.includes('Maple'));
+});
+
+test('watchChoiceFor defaults to web and honours per-league assignment', () => {
+  assert.equal(watchChoiceFor({}, 'NFL'), WATCH_WEB);
+  assert.equal(watchChoiceFor({ nfl: 'com.espn.score_center' }, 'NFL'), 'com.espn.score_center');
+  // falls back to the label key, and 'web' wins explicitly
+  assert.equal(watchChoiceFor({ NFL: 'com.dazn' }, 'NFL'), 'com.dazn');
+  assert.equal(watchChoiceFor({ nfl: WATCH_WEB, NFL: 'com.dazn' }, 'NFL'), WATCH_WEB);
+});


### PR DESCRIPTION
## Why this exists

Core Line v1.1.0 (PR #61) shipped the supporter feedback round — sport tabs, TV favorites, 10-foot pass. This integrates the remaining v1.2.0 handover: in-app sideload updates, a phone floating overlay, watch-app assignment, rewritten D-pad navigation, restructured settings, and a full TV consistency pass. 88/88 tests, soak-verified, two APKs built in the prior session (excluded from git — release asset lane).

## What changed

**New files (9):**
- `ticker/lib/version.mjs` — semver compare, GitHub release parse, update status (unit-tested)
- `ticker/lib/watch.mjs` — curated sports-app list, ESPN web URL builder, watch-app assignment logic (unit-tested)
- `ticker/android/.../UpdateManager.kt` — host-allowlisted APK download via FileProvider to system installer
- `ticker/android/.../OverlayService.kt` — phone floating ticker (translucent touch-through TYPE_APPLICATION_OVERLAY foreground service)
- `ticker/android/.../ic_notification.xml` — ticker-strip glyph for overlay notification
- `ticker/android/.../file_paths.xml` — FileProvider paths (cache/updates only)
- `ticker/tests/version.test.mjs` — 5 tests pinning semver/tag/status logic
- `ticker/tests/watch.test.mjs` — 6 tests pinning watch-app URL/assignment logic
- `ticker/tests/smoke-updates.mjs` — headless TV checks (health pill size, team name scale, abbr overflow)

**Modified files (13):**
- `ticker/android/app/build.gradle.kts` — versionCode 5, versionName 1.2.0
- `ticker/android/.../AndroidManifest.xml` — REQUEST_INSTALL_PACKAGES, FileProvider, SYSTEM_ALERT_WINDOW, FOREGROUND_SERVICE, OverlayService, `<queries>` for package visibility
- `ticker/android/.../MainActivity.kt` — listLaunchableApps/openApp/openUrl, getVersion/installUpdate, overlay start/stop
- `ticker/android/.../LineBridge.kt` — JS bridge for all new native features
- `ticker/public/index.html` — drawer restructured into rail + 5 sections (Feeds/Scoreboards/Ticker & display/Watch apps/Help), Updates pane
- `ticker/public/js/app.js` — watch buttons, updates panel, installUpdateFlow, sport super-tabs wiring
- `ticker/public/js/state.js` — watchApps persistence (leagueId to app pkg)
- `ticker/public/js/tv.js` — rewritten spatial D-pad nav (cross-axis overlap, scroll-into-view, focus confinement)
- `ticker/public/css/app.css` — coherent TV scale ladder (micro/body/control/title/display), tactile states, focus rings, broadcast labels, chyron edge fades, overlay CSS, reduced-motion
- `ticker/package.json` — version 1.2.0
- `ticker/AUDIT.md`, `ticker/CLAUDE_HANDOVER.md`, `ticker/VERIFICATION.md` — updated with rounds 8–8.5

## Verification

- [x] `npm test` in `ticker/` — 88/88 pass
- [x] No icon-pack files touched (ticker/ only)
- [x] APKs excluded from commit (release asset lane)
- [x] Workflow `.github/workflows/core-line-apk.yml` already deployed, unchanged

```
npm test → 88/88 pass (663 ms)
```

https://claude.ai/code/session_01RJbpQkj9fcYQq4sLMHkjVQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJbpQkj9fcYQq4sLMHkjVQ)_