### PR TITLE
chore: bump icon pack to v1.8.2

### DIFF
--- a/Latestrelease/version.json
+++ b/Latestrelease/version.json
@@ -1,6 +1,6 @@
 {
-  "versionCode": 14,
-  "versionName": "1.8.1",
+  "versionCode": 15,
+  "versionName": "1.8.2",
   "iconCount": 924,
   "componentCount": 1098,
   "releaseDate": "2026-09-04",

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
         applicationId = "tv.corebuilds.iconpack"
         minSdk = 21
         targetSdk = 34
-        versionCode = 14
-        versionName = "1.8.1"
+        versionCode = 15
+        versionName = "1.8.2"
     }
 
     signingConfigs {

--- a/tests/test_wallpaper_export.py
+++ b/tests/test_wallpaper_export.py
@@ -182,10 +182,10 @@ class KotlinWiringTests(unittest.TestCase):
 
 
 class VersionTests(unittest.TestCase):
-    def test_version_bumped_to_181(self):
+    def test_version_bumped_to_182(self):
         gradle = read("app/build.gradle.kts")
-        self.assertIn('versionCode = 14', gradle)
-        self.assertIn('versionName = "1.8.1"', gradle)
+        self.assertIn('versionCode = 15', gradle)
+        self.assertIn('versionName = "1.8.2"', gradle)
 
     def test_version_json_matches_gradle(self):
         import json


### PR DESCRIPTION
## Why this exists

The v1.8.1 APK was built before the 3 Core family icons (Core Line, Core Shift, Core Doctor) and the niche sports app additions landed on main. Users see v1.5.1 on their devices because the rolling `iconpack` release still carries the old build. Bumping to v1.8.2 so the `v1.8.2` tag triggers the full build+sign+publish pipeline, shipping the complete 924-icon pack and 26-app Watch picker to the `iconpack` release.

## What changed

- `app/build.gradle.kts` — versionCode 14 → 15, versionName 1.8.1 → 1.8.2
- `Latestrelease/version.json` — versionCode 14 → 15, versionName 1.8.1 → 1.8.2

## Verification

- [x] Version bump only — no catalog/glyph/asset changes

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJbpQkj9fcYQq4sLMHkjVQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJbpQkj9fcYQq4sLMHkjVQ)_