### PR TITLE
feat(ticker): add ScoreBox-style IPTV channel matching

### DIFF
--- a/ticker/android/app/src/main/java/dev/corebuilds/line/LineBridge.kt
+++ b/ticker/android/app/src/main/java/dev/corebuilds/line/LineBridge.kt
@@ -27,6 +27,10 @@ class LineBridge(private val activity: MainActivity) {
     @JavascriptInterface
     fun openApp(packageName: String): Boolean = activity.openApp(packageName)
 
+    /** Hand a playlist stream URL to an external player. Returns success. */
+    @JavascriptInterface
+    fun openStream(url: String): Boolean = activity.openStream(url)
+
     /** Open a URL in the system browser. Returns success. */
     @JavascriptInterface
     fun openUrl(url: String): Boolean = activity.openUrl(url)

--- a/ticker/android/app/src/main/java/dev/corebuilds/line/MainActivity.kt
+++ b/ticker/android/app/src/main/java/dev/corebuilds/line/MainActivity.kt
@@ -128,6 +128,33 @@ class MainActivity : Activity() {
         }
     }
 
+    /**
+     * Hand a playlist stream URL to an external player (TiviMate, VLC, …).
+     * Core Line never plays video itself — this is a pure handoff. Tries the
+     * HLS mime first for better player targeting, then generic video/*.
+     */
+    fun openStream(url: String): Boolean {
+        if (url.isBlank()) return false
+        val path = url.substringBefore('?').lowercase()
+        val mimes = if (path.endsWith(".m3u8") || path.endsWith(".m3u")) {
+            listOf("application/vnd.apple.mpegurl", "video/*")
+        } else {
+            listOf("video/*", "application/vnd.apple.mpegurl")
+        }
+        for (mime in mimes) {
+            try {
+                val intent = Intent(Intent.ACTION_VIEW)
+                    .setDataAndType(Uri.parse(url), mime)
+                    .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                startActivity(intent)
+                return true
+            } catch (err: Exception) {
+                // no activity for this mime — try the next
+            }
+        }
+        return false
+    }
+
     /** Current app version ("1.2.0") for the in-app Updates panel. */
     fun getVersion(): String = dev.corebuilds.line.BuildConfig.VERSION_NAME
 

--- a/ticker/android/app/src/main/java/dev/corebuilds/line/MainActivity.kt
+++ b/ticker/android/app/src/main/java/dev/corebuilds/line/MainActivity.kt
@@ -131,7 +131,7 @@ class MainActivity : Activity() {
     /**
      * Hand a playlist stream URL to an external player (TiviMate, VLC, …).
      * Core Line never plays video itself — this is a pure handoff. Tries the
-     * HLS mime first for better player targeting, then generic video/*.
+     * HLS mime first for better player targeting, then a generic video type.
      */
     fun openStream(url: String): Boolean {
         if (url.isBlank()) return false

--- a/ticker/lib/playlist.mjs
+++ b/ticker/lib/playlist.mjs
@@ -1,0 +1,295 @@
+/**
+ * IPTV playlist (M3U) support — ScoreBox-style game→channel matching.
+ *
+ * Core Line stays a guide, never a player: this module only reads the
+ * playlist the user supplies, figures out which of its channels carry a
+ * game, and hands the stream URL to an external player app.
+ *
+ * Pure functions only — no network, no DOM. The server proxies the actual
+ * M3U fetch (/api/playlist) with the same SSRF posture as RSS feeds.
+ */
+
+import { normalizeChannel } from './channels.mjs';
+
+/** Hard cap so a pathological playlist can't melt the TV. */
+export const MAX_CHANNELS = 4000;
+/** Longest channel name we keep (decorated IPTV names are noisy). */
+const MAX_NAME = 64;
+/** Longest stream URL we keep. */
+const MAX_URL = 500;
+
+/** Two-letter country prefixes seen in IPTV names ("US| FOX", "CA: TSN4"). */
+const COUNTRY_CODES = new Set([
+  'US', 'CA', 'UK', 'GB', 'AU', 'NZ', 'DE', 'FR', 'IT', 'ES', 'NL', 'BE',
+  'CH', 'AT', 'IE', 'PT', 'SE', 'NO', 'DK', 'FI', 'PL', 'CZ', 'SK', 'HU',
+  'RO', 'GR', 'TR', 'IL', 'SA', 'AE', 'IN', 'PK', 'BD', 'LK', 'JP', 'KR',
+  'CN', 'TW', 'HK', 'SG', 'MY', 'ID', 'TH', 'VN', 'PH', 'BR', 'MX', 'AR',
+  'CL', 'CO', 'PE', 'UY', 'EC', 'CR', 'PA', 'DO', 'VE', 'ZA', 'NG', 'KE',
+  'EG', 'MA', 'UA', 'RU', 'LT', 'LV', 'EE', 'HR', 'RS', 'SI', 'BG',
+]);
+
+/** Trailing quality/codec tags, strongest first (rank matches array order). */
+const QUALITY_TAGS = [
+  /\b(?:uhd|4k)\b/i,
+  /\bhdr(?:10\+?)?\b/i,
+  /\b(?:fhd|1080p?)\b/i,
+  /\bhd\b/i,
+];
+const QUALITY_TAG_RE = /[\s\-|·>]*\b(?:uhd|4k|hdr(?:10\+?)?|fhd|hd|sd|hevc|h\.?26[45]|1080p?|720p?|576p?|480p?)\b\s*$/i;
+/** Trailing emoji / symbol noise ("FOX ⚡", "TSN4 ✅"). */
+const EMOJI_TAIL_RE = /[\u{1F000}-\u{1FAFF}\u{2600}-\u{27BF}\u{2B00}-\u{2BFF}\u{FE0F}\u{2190}-\u{21FF}\u{2B50}]+\s*$/u;
+/** Generic words that must never count as a team-name match on their own. */
+const GENERIC_TOKENS = new Set([
+  'sports', 'sport', 'network', 'channel', 'channels', 'tv', 'television',
+  'hd', 'fhd', 'uhd', 'sd', '4k', 'one', 'two', 'three', 'plus', 'east',
+  'west', 'north', 'south', 'pacific', 'atlantic', 'central', 'world',
+  'news', 'radio', 'events', 'event', 'live', 'stream', 'main', 'feed',
+  'video', 'free', 'extra', 'premium', 'prime', 'fox', 'espn', 'sportsnet',
+  'tsn', 'cbc', 'nbc', 'cbs', 'abc', 'bein', 'sky', 'dazn',
+]);
+
+/**
+ * Parse M3U/M3U8 playlist text into a flat channel list.
+ * Tolerant by design: real-world playlists are hand-mangled.
+ *
+ * @param {string} text raw playlist body
+ * @param {{maxChannels?: number}} [opts]
+ * @returns {{ok: boolean, count: number, channels: Array<{name:string,url:string,group:string}>, error?: string}}
+ */
+export function parseM3U(text, { maxChannels = MAX_CHANNELS } = {}) {
+  const raw = String(text || '');
+  if (!raw.trim()) return { ok: false, count: 0, channels: [], error: 'empty playlist' };
+
+  const channels = [];
+  const seenUrls = new Set();
+  let pendingName = '';
+  let group = '';
+
+  const lines = raw.split(/\r?\n/);
+  for (const line of lines) {
+    const s = line.trim();
+    if (!s) continue;
+
+    if (s.startsWith('#EXTINF')) {
+      pendingName = extinfName(s);
+      const title = attr(s, 'group-title');
+      if (title) group = title.slice(0, 40);
+      continue;
+    }
+    if (s.startsWith('#EXTGRP:')) {
+      group = s.slice('#EXTGRP:'.length).trim().slice(0, 40);
+      continue;
+    }
+    if (s.startsWith('#')) continue; // #EXTM3U, #EXTVLCOPT, #KODIPROP, …
+
+    // A non-comment line is a candidate URL.
+    if (!/^https?:\/\//i.test(s)) continue;
+    if (seenUrls.has(s)) continue;
+    seenUrls.add(s);
+
+    const name = (pendingName || fallbackName(s, channels.length + 1)).slice(0, MAX_NAME).trim();
+    pendingName = '';
+    channels.push({
+      name,
+      url: s.slice(0, MAX_URL),
+      group,
+    });
+    if (channels.length >= maxChannels) break;
+  }
+
+  if (!channels.length) return { ok: false, count: 0, channels: [], error: 'no channels found in playlist' };
+  return { ok: true, count: channels.length, channels };
+}
+
+/** Display name from an #EXTINF line: text after the last comma, else tvg-name. */
+function extinfName(line) {
+  const comma = line.lastIndexOf(',');
+  if (comma !== -1 && comma < line.length - 1) {
+    const tail = line.slice(comma + 1).trim();
+    if (tail) return collapse(tail);
+  }
+  const tvg = attr(line, 'tvg-name');
+  return tvg ? collapse(tvg) : '';
+}
+
+/** value of a `key="value"` attribute, tolerant of missing quotes. */
+function attr(line, key) {
+  const re = new RegExp(`${key}\\s*=\\s*"([^"]*)"`, 'i');
+  const m = line.match(re);
+  if (m) return m[1];
+  const loose = line.match(new RegExp(`${key}\\s*=\\s*([^\\s,"]+)`, 'i'));
+  return loose ? loose[1] : '';
+}
+
+function fallbackName(url, n) {
+  try {
+    const u = new URL(url);
+    const last = u.pathname.split('/').filter(Boolean).pop() || u.hostname;
+    return decodeURIComponent(last).replace(/\.(m3u8?|ts|mp4)$/i, '') || `Channel ${n}`;
+  } catch {
+    return `Channel ${n}`;
+  }
+}
+
+function collapse(s) {
+  return String(s).replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Strip IPTV naming decorations so "US| FOX SPORTS UHD ⚡" → "FOX SPORTS".
+ * Country prefixes are only stripped for known codes ("TS4:" stays intact).
+ */
+export function stripDecorations(raw) {
+  let name = collapse(String(raw || ''));
+  name = name.replace(EMOJI_TAIL_RE, '').trim();
+  for (let i = 0; i < 2; i++) {
+    const m = name.match(/^([A-Za-z]{2})\s*[|:]\s*(.+)$/);
+    if (!m || !COUNTRY_CODES.has(m[1].toUpperCase())) break;
+    name = collapse(m[2]);
+  }
+  for (let i = 0; i < 2; i++) {
+    const next = name.replace(QUALITY_TAG_RE, '').trim();
+    if (next === name || !next) break;
+    name = next;
+  }
+  return name;
+}
+
+/** Lower rank = better-looking stream (UHD beats HD beats nothing). */
+export function qualityRank(rawName) {
+  const s = String(rawName || '');
+  for (let i = 0; i < QUALITY_TAGS.length; i++) {
+    if (QUALITY_TAGS[i].test(s)) return i;
+  }
+  return /\bsd\b/i.test(s) ? 5 : 4;
+}
+
+/** The network "bug" a playlist channel name collapses to ("US| TSN4 HD" → "TSN4"). */
+export function networkBugFor(rawName) {
+  return normalizeChannel(stripDecorations(rawName));
+}
+
+/**
+ * Build a lookup index over a parsed channel list.
+ * @returns {{byNetwork: Map<string, number[]>, byToken: Map<string, number[]>}}
+ */
+export function buildChannelIndex(channels) {
+  const byNetwork = new Map();
+  const byToken = new Map();
+  (channels || []).forEach((ch, i) => {
+    const bug = networkBugFor(ch.name);
+    if (bug && bug.length >= 2) push(byNetwork, bug, i);
+    for (const token of tokenize(stripDecorations(ch.name))) push(byToken, token, i);
+  });
+  return { byNetwork, byToken };
+}
+
+function push(map, key, i) {
+  const list = map.get(key);
+  if (list) list.push(i);
+  else map.set(key, [i]);
+}
+
+// Indexes are memoized per channel-list identity: the list is imported once
+// and matched on every Game Detail open — don't rebuild a 4k-channel index
+// each time.
+const indexCache = new WeakMap();
+
+function indexFor(channels) {
+  if (!Array.isArray(channels)) return buildChannelIndex([]);
+  let index = indexCache.get(channels);
+  if (!index) {
+    index = buildChannelIndex(channels);
+    indexCache.set(channels, index);
+  }
+  return index;
+}
+
+function tokenize(stripped) {
+  return collapse(stripped.toLowerCase())
+    .split(/[^a-z0-9+]+/)
+    .filter((t) => t.length >= 3 && !GENERIC_TOKENS.has(t));
+}
+
+/**
+ * Match a game event to playlist channels, best first.
+ *
+ * Tier bases (lower = better): network bug 0 (preferred −50) > full team
+ * name 20 > team abbr 40 > city 60. Ties inside a tier prefer higher-quality
+ * streams and shorter names.
+ *
+ * @param {object} ev event with `channels` (bugs) and `away`/`home` teams
+ * @param {Array<{name:string,url:string}>} channels parsed playlist channels
+ * @param {{index?: object, limit?: number, preferred?: Record<string,string>}} [opts]
+ * @returns {Array<{name:string,url:string,group:string,reason:'network'|'team',score:number,preferred:boolean,bug:string}>}
+ */
+export function matchChannels(ev, channels, opts = {}) {
+  const { index = indexFor(channels), limit = 6, preferred = {} } = opts;
+  if (!ev || !channels || !channels.length) return [];
+
+  const best = new Map(); // channel index → match record
+
+  const consider = (i, base, reason, bug) => {
+    const ch = channels[i];
+    const score = base + qualityRank(ch.name) * 2 + Math.min(ch.name.length / 200, 0.5);
+    const prev = best.get(i);
+    if (prev && prev.score <= score) return;
+    best.set(i, {
+      name: ch.name,
+      url: ch.url,
+      group: ch.group || '',
+      reason,
+      score,
+      preferred: Boolean(bug && preferred[bug] === ch.name),
+      bug: bug || '',
+    });
+  };
+
+  // Tier 1 — network bug exact match ("FS1", "TSN4", "SN 3").
+  const bugs = [...new Set((ev.channels || []).map(String).filter(Boolean))];
+  for (const bug of bugs) {
+    for (const i of index.byNetwork.get(bug) || []) {
+      const base = preferred[bug] === channels[i].name ? -50 : 0;
+      consider(i, base, 'network', bug);
+    }
+  }
+
+  // Tier 2/3/4 — channels named for the teams or city.
+  const teams = [ev.away, ev.home].filter(Boolean);
+  const fullNames = teams.map((t) => collapse(String(t.name || '').toLowerCase())).filter((n) => n.length >= 5);
+  const abbrs = teams.map((t) => collapse(String(t.abbr || '').toLowerCase())).filter((a) => a.length >= 3);
+  const cities = teams
+    .map((t) => collapse(String(t.name || '').toLowerCase()).split(' ')[0])
+    .filter((c) => c.length >= 4 && !GENERIC_TOKENS.has(c));
+
+  if (fullNames.length || abbrs.length || cities.length) {
+    const candidateIdx = new Set();
+    const probeTokens = new Set([
+      ...fullNames.flatMap((n) => n.split(' ').filter((w) => w.length >= 4 && !GENERIC_TOKENS.has(w))),
+      ...abbrs,
+      ...cities,
+    ]);
+    for (const tok of probeTokens) {
+      for (const i of index.byToken.get(tok) || []) candidateIdx.add(i);
+    }
+
+    for (const i of candidateIdx) {
+      const strippedName = collapse(stripDecorations(channels[i].name).toLowerCase());
+      for (const full of fullNames) {
+        if (strippedName.includes(full)) { consider(i, 20, 'team', ''); break; }
+      }
+      if (best.get(i)?.reason === 'team') continue;
+      for (const abbr of abbrs) {
+        if (tokenize(stripDecorations(channels[i].name)).includes(abbr)) { consider(i, 40, 'team', ''); break; }
+      }
+      if (best.get(i)?.reason === 'team') continue;
+      for (const city of cities) {
+        if (strippedName.includes(city)) { consider(i, 60, 'team', ''); break; }
+      }
+    }
+  }
+
+  return [...best.values()]
+    .sort((a, b) => a.score - b.score)
+    .slice(0, Math.max(0, limit));
+}

--- a/ticker/public/css/app.css
+++ b/ticker/public/css/app.css
@@ -934,3 +934,68 @@ input[type="checkbox"], input[type="radio"], input[type="range"] { accent-color:
 [data-overlay] .tick::after { margin-left: 18px; }
 [data-overlay] .tick .k { font-size: .8rem; }
 [data-overlay] .chyron-clock { min-width: 76px; font-size: 1.05rem; }
+
+/* ============================================================
+   Game Detail modal — ScoreBox-style channel matching + handoff
+   ============================================================ */
+.game-detail {
+  position: fixed;
+  inset: 0;
+  z-index: 70;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 22px;
+  background: rgba(4, 9, 15, .66);
+}
+.game-detail[hidden] { display: none; }
+.game-detail-panel {
+  width: min(720px, 96vw);
+  max-height: min(84vh, 760px);
+  overflow-y: auto;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  padding: 20px 22px 22px;
+  box-shadow: 0 30px 90px rgba(0, 0, 0, .55);
+  animation: drawer-in .18s ease;
+}
+.gd-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; }
+.gd-meta {
+  display: flex; gap: 10px; align-items: center; flex-wrap: wrap;
+  color: var(--muted); font-size: .8rem;
+  text-transform: uppercase; letter-spacing: .08em;
+}
+.gd-teams .team-row { padding: 8px 0; }
+.gd-pills { display: flex; flex-wrap: wrap; gap: 6px; margin: 10px 0 2px; }
+.gd-actions { display: flex; gap: 10px; margin: 14px 0 4px; flex-wrap: wrap; }
+.gd-section {
+  margin: 16px 0 8px; font-size: .78rem; color: var(--faint);
+  text-transform: uppercase; letter-spacing: .12em;
+}
+.gd-row {
+  display: flex; width: 100%; align-items: center; gap: 10px;
+  text-align: left; padding: 11px 12px; margin: 6px 0;
+  border-radius: 12px; background: var(--card);
+  border: 1px solid var(--border); color: var(--text); font: inherit;
+  cursor: pointer;
+}
+.gd-row .gd-ch { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.gd-why {
+  font-size: .68rem; letter-spacing: .08em; color: var(--faint);
+  border: 1px solid var(--border); padding: 2px 7px; border-radius: 999px;
+  white-space: nowrap;
+}
+.gd-star { color: var(--up); }
+.gd-open { color: var(--line); font-size: .82rem; white-space: nowrap; }
+.gd-foot { margin-top: 12px; color: var(--faint); font-size: .78rem; }
+.game.focusable, .hero-card.focusable { cursor: pointer; }
+
+[data-tv] .game-detail-panel { width: min(860px, 94vw); padding: 28px 30px; }
+[data-tv] .gd-row { padding: 16px 18px; font-size: 1.15rem; margin: 8px 0; }
+[data-tv] .gd-meta { font-size: 1rem; }
+[data-tv] .gd-why { font-size: .78rem; }
+[data-tv] .gd-actions .watch-btn, [data-tv] .gd-actions .ghost { font-size: 1.1rem; padding: 12px 22px; }
+@media (prefers-reduced-motion: reduce) {
+  .game-detail-panel { animation: none; }
+}

--- a/ticker/public/index.html
+++ b/ticker/public/index.html
@@ -95,6 +95,7 @@
             <button class="rail-item focusable" data-action="drawer-section" data-section="scoreboards" aria-pressed="false"><span class="rail-ic">🏆</span> Scoreboards</button>
             <button class="rail-item focusable" data-action="drawer-section" data-section="ticker" aria-pressed="false"><span class="rail-ic">🎚️</span> Ticker &amp; display</button>
             <button class="rail-item focusable" data-action="drawer-section" data-section="watch" aria-pressed="false"><span class="rail-ic">▶️</span> Watch apps</button>
+            <button class="rail-item focusable" data-action="drawer-section" data-section="channels" aria-pressed="false"><span class="rail-ic">📺</span> Channels</button>
             <button class="rail-item focusable" data-action="drawer-section" data-section="updates" aria-pressed="false"><span class="rail-ic">⬇️</span> Updates</button>
             <button class="rail-item focusable" data-action="drawer-section" data-section="about" aria-pressed="false"><span class="rail-ic">?</span> Help &amp; about</button>
           </nav>
@@ -196,6 +197,18 @@
               <p class="hint small" id="watchAppsStatus"></p>
             </section>
 
+            <section class="block drawer-section" data-panel="channels">
+              <h3>IPTV playlist (M3U)</h3>
+              <p class="hint">Import the M3U link from your IPTV provider (Xtream “m3u_plus” links work too). Game details then list your channels that carry the game, and open them in your player app — Core Line itself never plays video.</p>
+              <div class="feed-add">
+                <input class="focusable" id="playlistUrl" type="url" placeholder="https://provider.example/get.php?…m3u_plus" autocomplete="off" spellcheck="false">
+                <button class="primary focusable" data-action="playlist-import" id="playlistImportBtn">Import</button>
+              </div>
+              <p class="hint small" id="playlistStatus"></p>
+              <button class="ghost focusable" data-action="playlist-clear" id="playlistClearBtn" hidden>Remove playlist</button>
+              <p class="hint small">The link is fetched by Core Line on this device and never leaves it. Opening a channel needs a player that accepts stream links — TiviMate, VLC, or similar.</p>
+            </section>
+
             <section class="block drawer-section" data-panel="updates">
               <h3>Updates</h3>
               <p class="hint">Core Line updates come from the GitHub release feed. On a TV, download the new APK and the system installer takes over — your settings are kept.</p>
@@ -225,6 +238,10 @@
       </div>
       <div class="chyron-clock" id="clock">00:00</div>
     </footer>
+  </div>
+
+  <div class="game-detail" id="gameDetail" hidden>
+    <div class="game-detail-panel" id="gameDetailPanel" role="dialog" aria-modal="true" aria-label="Game detail"></div>
   </div>
 
   <div class="toast" id="toast" hidden></div>

--- a/ticker/public/js/app.js
+++ b/ticker/public/js/app.js
@@ -1,10 +1,11 @@
 import { toTickerText, parseFeed } from '/lib/parser.mjs';
 import { LEAGUES, LEAGUE_LABELS, SPORT_GROUPS, compareEvents, buildDemoSlate, mergeEvents } from '/lib/scoreboard.mjs';
 import { WATCH_WEB, sortAppsForPicker, espnWebUrl, watchChoiceFor } from '/lib/watch.mjs';
+import { matchChannels } from '/lib/playlist.mjs';
 import { updateStatus as buildUpdateStatus } from '/lib/version.mjs';
 import { buildClientSlate, isNativeShell, hydrateClientSlateRegistry, getClientSlateRegistry } from '/lib/client-slate.mjs';
 import { isSafeFeedUrl } from '/lib/ssrf.mjs';
-import { loadState, saveState, cacheSlate, readCachedSlate, REFRESH_CHOICES, SPEED_MIN, SPEED_MAX } from './state.js';
+import { loadState, saveState, cacheSlate, readCachedSlate, REFRESH_CHOICES, SPEED_MIN, SPEED_MAX, DEFAULTS, savePlaylistChannels, readPlaylistChannels } from './state.js';
 import { initTvNav } from './tv.js';
 import { qrDataUrl } from './qr.js';
 import { Ticker } from './ticker.js';
@@ -33,6 +34,13 @@ const MAX_FEEDS = 20;
 const $ = (id) => document.getElementById(id);
 
 const state = loadState();
+
+// Imported IPTV playlist (ScoreBox-style channel matching). The channel list
+// is big, so it lives under its own storage key; state only keeps metadata.
+let playlistChannels = readPlaylistChannels();
+let detailEvent = null;
+let detailMatches = [];
+let lastFocusBeforeDetail = null;
 let events = [];
 let wakeLock = null;
 let clockTimer = null;
@@ -137,6 +145,17 @@ function bind() {
     if (action === 'toggle-team') toggleTeam(btn.dataset.abbr);
     if (action === 'toggle-card-fav') toggleCardFav(btn.dataset.id);
     if (action === 'watch') watchEventById(btn.dataset.id);
+    if (action === 'watch-web') openWebForEvent(btn.dataset.id);
+    if (action === 'game-detail') openGameDetail(btn.dataset.id);
+    if (action === 'detail-close') closeGameDetail();
+    if (action === 'open-channel') openMatchedChannel(Number(btn.dataset.mindex));
+    if (action === 'open-channels-settings') {
+      closeGameDetail();
+      openDrawer(true);
+      activateDrawerSection('channels');
+    }
+    if (action === 'playlist-import') importPlaylist();
+    if (action === 'playlist-clear') clearPlaylist();
     if (action === 'drawer-section') activateDrawerSection(btn.dataset.section);
     if (action === 'check-updates') checkForUpdates(true);
     if (action === 'install-update') installUpdateFlow();
@@ -224,6 +243,12 @@ function bind() {
     if (key === 't') toggleMode();
     if (key === 'r') refresh(true);
     if (key === 'w') {
+      // While Game Detail is open, W targets the game in the modal — not a
+      // background one.
+      if (detailEvent) {
+        if (detailEvent.away && detailEvent.home) watchEventById(detailEvent.id);
+        return;
+      }
       const featured = events.find((e) => e.status === 'live' && e.away && e.home)
         || events.find((e) => e.status === 'upcoming' && e.away && e.home);
       if (featured) watchEventById(featured.id);
@@ -234,6 +259,14 @@ function bind() {
   $('drawer').addEventListener('click', (event) => {
     if (event.target.id === 'drawer') openDrawer(false);
   });
+
+  // Game Detail modal: click the backdrop to close (D-pad Back does the same).
+  const gd = $('gameDetail');
+  if (gd) {
+    gd.addEventListener('click', (event) => {
+      if (event.target.id === 'gameDetail') closeGameDetail();
+    });
+  }
 
   // TV sidebar behaviour: focusing a rail item selects its section, so
   // D-pad up/down through the rail shows each section as you pass it.
@@ -320,6 +353,7 @@ function applyChrome() {
       overlayHint.textContent = 'Draws the crawl on top of every app, edge to edge. Stop it from the notification or untick this box.';
     }
   }
+  renderChannelsPanel();
   if (!globalThis.CORELINE_OVERLAY) syncWakeLock();
 }
 
@@ -329,6 +363,7 @@ function persist() {
 
 function openDrawer(open) {
   const drawer = $('drawer');
+  if (open && !$('gameDetail').hidden) closeGameDetail(); // one modal at a time
   drawer.hidden = !open;
   if (open) {
     lastFocusBeforeDrawer = document.activeElement;
@@ -360,6 +395,7 @@ function activateDrawerSection(name) {
     s.classList.toggle('is-active', s.dataset.panel === name);
   });
   if (name === 'watch') renderWatchApps();
+  if (name === 'channels') renderChannelsPanel();
   if (name === 'updates') {
     renderUpdates();
     if (!updateInfo && !updateChecking) checkForUpdates(false);
@@ -492,6 +528,169 @@ async function watchEventById(id) {
   }
   try { window.open(url, '_blank', 'noopener'); } catch { /* ignore */ }
   toast('Opening in browser');
+}
+
+/** Open a game's ESPN page directly (web fallback from Game Detail). */
+function openWebForEvent(id) {
+  const ev = events.find((e) => e.id === id);
+  if (!ev) return;
+  const url = espnWebUrl(ev);
+  const bridge = nativeBridge();
+  if (bridge?.openUrl) {
+    try { if (bridge.openUrl(url)) return; } catch { /* ignore */ }
+  }
+  try { window.open(url, '_blank', 'noopener'); } catch { /* ignore */ }
+  toast('Opening in browser');
+}
+
+/* ------------------------------------------------------------------ *
+ * IPTV playlist — ScoreBox-style channel matching + handoff.
+ * Core Line matches games to the user's own channels and opens them in
+ * an external player; it never plays video itself.
+ * ------------------------------------------------------------------ */
+
+function renderChannelsPanel() {
+  const input = $('playlistUrl');
+  if (!input) return;
+  if (state.playlist.url && document.activeElement !== input) input.value = state.playlist.url;
+  const n = playlistChannels.length;
+  const when = state.playlist.importedAt ? ` · imported ${new Date(state.playlist.importedAt).toLocaleDateString()}` : '';
+  $('playlistStatus').textContent = n
+    ? `${n} channels${when}${n !== state.playlist.count ? ' (cached)' : ''}`
+    : 'No playlist imported yet.';
+  const clearBtn = $('playlistClearBtn');
+  if (clearBtn) clearBtn.hidden = !n && !state.playlist.url;
+}
+
+async function importPlaylist() {
+  const url = $('playlistUrl')?.value.trim();
+  if (!url) { toast('Paste your M3U link first'); return; }
+  const btn = $('playlistImportBtn');
+  if (btn) btn.disabled = true;
+  $('playlistStatus').textContent = 'Importing…';
+  try {
+    const res = await fetch(`/api/playlist?url=${encodeURIComponent(url)}`);
+    const data = await res.json().catch(() => ({ ok: false, error: 'bad response' }));
+    if (!data.ok) {
+      toast(`Import failed: ${data.error || 'unknown error'}`);
+      return;
+    }
+    playlistChannels = data.channels || [];
+    const stored = savePlaylistChannels(playlistChannels);
+    state.playlist = { url, importedAt: Date.now(), count: data.count || playlistChannels.length };
+    persist();
+    toast(`Imported ${data.count || playlistChannels.length} channels${stored ? '' : ' — storage full, kept for this session'}`);
+  } catch (err) {
+    toast(`Import failed: ${err?.message || 'network error'}`);
+  } finally {
+    if (btn) btn.disabled = false;
+    renderChannelsPanel();
+  }
+}
+
+function clearPlaylist() {
+  playlistChannels = [];
+  savePlaylistChannels([]);
+  state.playlist = { ...DEFAULTS.playlist };
+  state.preferredChannels = {};
+  persist();
+  renderChannelsPanel();
+  toast('Playlist removed');
+}
+
+function openGameDetail(id) {
+  const ev = events.find((e) => e.id === id);
+  if (!ev) return;
+  detailEvent = ev;
+  detailMatches = playlistChannels.length
+    ? matchChannels(ev, playlistChannels, { limit: 6, preferred: state.preferredChannels })
+    : [];
+  lastFocusBeforeDetail = document.activeElement;
+  $('gameDetailPanel').innerHTML = gameDetailHtml(ev, detailMatches, playlistChannels.length > 0);
+  const overlay = $('gameDetail');
+  overlay.hidden = false;
+  overlay.querySelector('.focusable')?.focus();
+}
+
+function closeGameDetail() {
+  const overlay = $('gameDetail');
+  if (overlay.hidden) return;
+  overlay.hidden = true;
+  detailEvent = null;
+  detailMatches = [];
+  if (lastFocusBeforeDetail && document.contains(lastFocusBeforeDetail)) {
+    lastFocusBeforeDetail.focus();
+  } else {
+    document.querySelector('.stage .focusable')?.focus();
+  }
+  lastFocusBeforeDetail = null;
+}
+
+function gameDetailHtml(ev, matches, hasPlaylist) {
+  const badge = ev.status === 'live' ? 'live' : ev.status === 'final' ? 'final' : 'upcoming';
+  const label = ev.status === 'live' ? (ev.detail || 'LIVE') : ev.status === 'final' ? 'FINAL' : (ev.detail || 'UPCOMING');
+  const pills = (ev.channels || []).map((c) => `<span class="pill">${esc(c)}</span>`).join('');
+  const teams = ev.away && ev.home
+    ? `<div class="teams">${teamLine(ev.away, ev)}${teamLine(ev.home, ev)}</div>`
+    : (ev.headline ? `<p class="hint">${esc(ev.headline)}</p>` : '');
+
+  let channelBlock;
+  if (!hasPlaylist) {
+    channelBlock = `
+      <p class="hint">Import your IPTV playlist to see which of your channels carry this game.</p>
+      <button class="ghost focusable" data-action="open-channels-settings">Set up in Settings → Channels</button>`;
+  } else if (!matches.length) {
+    channelBlock = `
+      <p class="hint">No channels matched ${esc((ev.channels || []).join(', ') || 'this game')}. Your provider may carry it under a different network name.</p>`;
+  } else {
+    channelBlock = matches.map((m, i) => `
+      <button class="gd-row focusable" data-action="open-channel" data-mindex="${i}">
+        <span class="gd-ch">${esc(m.name)}</span>
+        ${m.group ? `<span class="gd-why">${esc(m.group)}</span>` : ''}
+        <span class="gd-why">${m.reason === 'network' ? 'NETWORK' : 'TEAM'}</span>
+        ${m.preferred ? '<span class="gd-star" title="Preferred channel">★</span>' : ''}
+        <span class="gd-open">Open ▸</span>
+      </button>`).join('');
+  }
+
+  return `
+    <header class="gd-head">
+      <div class="gd-meta">
+        <span class="badge ${badge}">${esc(label)}</span>
+        <span>${esc(ev.league || ev.feed || '')}</span>
+      </div>
+      <button class="icon-btn focusable" data-action="detail-close" aria-label="Close">✕</button>
+    </header>
+    ${teams}
+    ${pills ? `<div class="gd-pills">${pills}</div>` : ''}
+    <div class="gd-actions">
+      ${ev.away && ev.home ? `<button class="watch-btn focusable" data-action="watch" data-id="${esc(ev.id)}">▶ Watch</button>` : ''}
+      <button class="ghost focusable" data-action="watch-web" data-id="${esc(ev.id)}">Web page</button>
+    </div>
+    <div class="gd-section">Your channels</div>
+    ${channelBlock}
+    <div class="gd-foot">${esc(ev.venue || ev.feed || '')}</div>
+  `;
+}
+
+/** Open a matched playlist channel in an external player; remember the choice. */
+function openMatchedChannel(i) {
+  const m = detailMatches[i];
+  if (!m) return;
+  if (m.bug) {
+    state.preferredChannels[m.bug] = m.name;
+    persist();
+  }
+  const bridge = nativeBridge();
+  if (bridge?.openStream) {
+    try {
+      const ok = bridge.openStream(m.url);
+      if (ok) { toast('Opening in player…'); return; }
+      toast('No player found — try TiviMate or VLC');
+    } catch { /* fall through to web */ }
+  }
+  try { window.open(m.url, '_blank', 'noopener'); toast('Opening stream link'); } catch { /* ignore */ }
+  toast('Could not open stream');
 }
 
 function toggleMode() {
@@ -964,7 +1163,7 @@ function renderHero(list) {
   }
   hero.hidden = false;
   hero.innerHTML = `
-    <article class="hero-card focusable" tabindex="0" style="--acc:${esc(accentFor(featured))}">
+    <article class="hero-card focusable" tabindex="0" data-action="game-detail" data-id="${esc(featured.id)}" style="--acc:${esc(accentFor(featured))}">
       <div>
         <div class="hero-meta">
           <span class="badge live">LIVE</span>
@@ -1012,7 +1211,7 @@ function gameCard(ev) {
   const teams = cardFavTeams(ev);
   const favOn = teams.length > 0 && teams.every((t) => favs.has(t));
   return `
-    <article class="game focusable" tabindex="0" style="--acc:${esc(accentFor(ev))}">
+    <article class="game focusable" tabindex="0" data-action="game-detail" data-id="${esc(ev.id)}" style="--acc:${esc(accentFor(ev))}">
       <div class="game-top">
         <span class="league-tag">${esc(ev.league || ev.feed || 'RSS')}</span>
         <div class="game-top-right">
@@ -1034,7 +1233,7 @@ function gameCard(ev) {
 
 function headlineCard(ev) {
   return `
-    <article class="game focusable" tabindex="0" style="--acc:${esc(accentFor(ev))}">
+    <article class="game focusable" tabindex="0" data-action="game-detail" data-id="${esc(ev.id)}" style="--acc:${esc(accentFor(ev))}">
       <div class="game-top">
         <span class="league-tag">${esc(ev.league || ev.feed || 'RSS')}</span>
         <span class="badge ${ev.status}">${esc(ev.status.toUpperCase())}</span>

--- a/ticker/public/js/state.js
+++ b/ticker/public/js/state.js
@@ -21,6 +21,8 @@ export const DEFAULTS = {
   refreshSec: 60,
   position: 'bottom',
   watchApps: {},
+  playlist: { url: '', importedAt: 0, count: 0 },
+  preferredChannels: {},
   overlay: false,
 };
 
@@ -75,6 +77,28 @@ export function sanitizeState(raw) {
       .map(([k, v]) => [k, v.slice(0, 200)]),
   );
 
+  // playlist: metadata only — the channel list itself is too big for the
+  // main state blob and lives under its own key (see savePlaylistChannels).
+  if (!out.playlist || typeof out.playlist !== 'object' || Array.isArray(out.playlist)) {
+    out.playlist = { ...DEFAULTS.playlist };
+  }
+  out.playlist = {
+    url: typeof out.playlist.url === 'string' ? out.playlist.url.slice(0, 500) : '',
+    importedAt: Number.isFinite(Number(out.playlist.importedAt)) ? Number(out.playlist.importedAt) : 0,
+    count: clampInt(out.playlist.count, 0, 1_000_000, 0),
+  };
+
+  // preferredChannels: network bug ("TSN4") → channel name ("US| TSN4 UHD").
+  if (!out.preferredChannels || typeof out.preferredChannels !== 'object' || Array.isArray(out.preferredChannels)) {
+    out.preferredChannels = {};
+  }
+  out.preferredChannels = Object.fromEntries(
+    Object.entries(out.preferredChannels)
+      .filter(([k, v]) => typeof k === 'string' && typeof v === 'string')
+      .map(([k, v]) => [k.slice(0, 24), v.slice(0, 64)])
+      .slice(0, 50),
+  );
+
   return out;
 }
 
@@ -107,6 +131,40 @@ export function cacheSlate(payload) {
     localStorage.setItem(`${KEY}.slate`, JSON.stringify({ at: Date.now(), payload }));
   } catch {
     /* quota */
+  }
+}
+
+/**
+ * Imported playlist channels live under their own key: a 4k-channel list
+ * would crowd the main state blob against the localStorage quota.
+ * Returns false when storage refused the write (quota) — caller keeps the
+ * channels in memory for this session.
+ */
+export function savePlaylistChannels(channels) {
+  try {
+    const clean = (Array.isArray(channels) ? channels : [])
+      .filter((c) => c && typeof c.name === 'string' && typeof c.url === 'string')
+      .map((c) => ({ name: c.name.slice(0, 64), url: c.url.slice(0, 500), group: String(c.group || '').slice(0, 40) }))
+      .slice(0, 4000);
+    localStorage.setItem(`${KEY}.channels`, JSON.stringify(clean));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function readPlaylistChannels() {
+  try {
+    const raw = localStorage.getItem(`${KEY}.channels`);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter((c) => c && typeof c.name === 'string' && typeof c.url === 'string')
+      .map((c) => ({ name: String(c.name).slice(0, 64), url: String(c.url).slice(0, 500), group: String(c.group || '').slice(0, 40) }))
+      .slice(0, 4000);
+  } catch {
+    return [];
   }
 }
 

--- a/ticker/public/js/tv.js
+++ b/ticker/public/js/tv.js
@@ -16,6 +16,13 @@ export function initTvNav(root) {
       return;
     }
     if (dir === 'back') {
+      // Back closes the topmost layer: Game Detail first, then the drawer.
+      const detail = document.getElementById('gameDetail');
+      if (detail && !detail.hidden) {
+        event.preventDefault();
+        detail.querySelector('[data-action="detail-close"]')?.click();
+        return;
+      }
       const close = root.querySelector('[data-action="close-settings"]');
       if (close && !document.getElementById('drawer').hidden) {
         event.preventDefault();
@@ -45,8 +52,11 @@ export function initTvNav(root) {
 
 function nearest(current, dir) {
   const drawerOpen = drawerShown();
+  const detailOpen = detailShown();
   const nodes = [...document.querySelectorAll('.focusable')].filter((el) => {
     if (!visible(el)) return false;
+    // While the Game Detail modal is open, D-pad stays inside it.
+    if (detailOpen) return el.closest('#gameDetail') !== null;
     if (drawerOpen && !el.closest('#drawer')) return false;
     return true;
   });
@@ -130,6 +140,11 @@ function visible(el) {
 function drawerShown() {
   const drawer = document.getElementById('drawer');
   return Boolean(drawer && !drawer.hidden);
+}
+
+function detailShown() {
+  const detail = document.getElementById('gameDetail');
+  return Boolean(detail && !detail.hidden);
 }
 
 function isEditing(el) {

--- a/ticker/server.mjs
+++ b/ticker/server.mjs
@@ -8,6 +8,7 @@ import { fetchFeed, fetchJson } from './lib/rss.mjs';
 import { isSafeFeedUrl } from './lib/ssrf.mjs';
 import { parseFeed } from './lib/parser.mjs';
 import { createBackoff } from './lib/backoff.mjs';
+import { parseM3U } from './lib/playlist.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PUBLIC_DIR = path.join(__dirname, 'public');
@@ -79,6 +80,18 @@ const server = http.createServer(async (req, res) => {
       json(res, result);
       return;
     }
+    if (url.pathname === '/api/playlist') {
+      // IPTV M3U import — same SSRF/fetch posture as /api/rss.
+      const target = url.searchParams.get('url') || '';
+      const safety = isSafeFeedUrl(target);
+      if (!safety.ok) {
+        json(res, { ok: false, error: safety.reason, count: 0, channels: [] }, 400);
+        return;
+      }
+      const payload = await cached(`playlist:${safety.url}`, () => fetchPlaylist(safety.url));
+      json(res, payload);
+      return;
+    }
     if (url.pathname === '/api/slate') {
       const leagues = (url.searchParams.get('leagues') || DEFAULT_LEAGUES.join(','))
         .split(',')
@@ -119,6 +132,46 @@ const server = http.createServer(async (req, res) => {
 server.listen(PORT, HOST, () => {
   console.log(`Core Line listening on http://${HOST}:${PORT}`);
 });
+
+const PLAYLIST_MAX_BYTES = 4_000_000;
+const PLAYLIST_TIMEOUT_MS = 12_000;
+
+/** Fetch and parse an M3U playlist (SSRF check happens at the route). */
+async function fetchPlaylist(url) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), PLAYLIST_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      signal: controller.signal,
+      headers: {
+        'user-agent': 'CoreLine/1.0 (+https://github.com/brevityA/CoreBuildsApps)',
+        accept: '*/*',
+      },
+      redirect: 'follow',
+    });
+    if (!res.ok) return { ok: false, error: `playlist returned ${res.status}`, count: 0, channels: [] };
+    if (!res.body) return { ok: false, error: 'empty response body', count: 0, channels: [] };
+    const chunks = [];
+    let bytes = 0;
+    for await (const chunk of res.body) {
+      bytes += chunk.length;
+      if (bytes > PLAYLIST_MAX_BYTES) {
+        controller.abort();
+        return { ok: false, error: 'playlist too large', count: 0, channels: [] };
+      }
+      chunks.push(chunk);
+    }
+    const text = Buffer.concat(chunks).toString('utf8');
+    const parsed = parseM3U(text);
+    if (!parsed.ok) return { ok: false, error: parsed.error || 'unparseable playlist', count: 0, channels: [] };
+    return { ok: true, count: parsed.count, channels: parsed.channels };
+  } catch (err) {
+    const message = err?.name === 'AbortError' ? 'playlist timed out' : (err?.message || 'fetch failed');
+    return { ok: false, error: message, count: 0, channels: [] };
+  } finally {
+    clearTimeout(timer);
+  }
+}
 
 async function getScoreboard(leagues) {
   return cached(`board:${leagues.join(',')}`, async () => {

--- a/ticker/tests/playlist.test.mjs
+++ b/ticker/tests/playlist.test.mjs
@@ -1,0 +1,172 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  parseM3U, stripDecorations, networkBugFor, qualityRank,
+  buildChannelIndex, matchChannels, MAX_CHANNELS,
+} from '../lib/playlist.mjs';
+
+const ev = (channels, awayName = 'Toronto Maple Leafs', awayAbbr = 'TOR', homeName = 'Montreal Canadiens', homeAbbr = 'MTL') => ({
+  channels,
+  away: { name: awayName, abbr: awayAbbr },
+  home: { name: homeName, abbr: homeAbbr },
+});
+
+test('parseM3U reads EXTINF name, tvg-name and group-title', () => {
+  const out = parseM3U([
+    '#EXTM3U',
+    '#EXTINF:-1 tvg-id="tsn4" tvg-name="TSN 4" group-title="Canada",TSN4 HD',
+    'http://a.example/tsn4.m3u8',
+    '#EXTINF:-1 group-title="Sports",Fox Sports',
+    'https://b.example/fox',
+  ].join('\n'));
+  assert.equal(out.ok, true);
+  assert.equal(out.count, 2);
+  assert.deepEqual(out.channels[0], { name: 'TSN4 HD', url: 'http://a.example/tsn4.m3u8', group: 'Canada' });
+  assert.equal(out.channels[1].group, 'Sports');
+});
+
+test('parseM3U falls back to tvg-name when nothing follows the comma', () => {
+  const out = parseM3U('#EXTINF:-1 tvg-name="ESPN Full",\nhttp://x.example/e');
+  assert.equal(out.ok, true);
+  assert.equal(out.channels[0].name, 'ESPN Full');
+});
+
+test('parseM3U handles CRLF, #EXTGRP, plain URL lines and skips junk', () => {
+  const out = parseM3U([
+    '#EXTM3U',
+    '#EXTGRP:Regional',
+    'http://plain.example/one',           // no EXTINF → fallback name from path
+    'ftp://blocked.example/two',          // non-http → skipped
+    '#EXTVLCOPT:http-user-agent=UA',      // ignored, and does not eat pending name
+    'not a url at all',
+    '#EXTINF:-1,Named',
+    'http://named.example/three',
+  ].join('\r\n'));
+  assert.equal(out.ok, true);
+  assert.equal(out.count, 2);
+  assert.equal(out.channels[0].group, 'Regional');
+  assert.equal(out.channels[0].name, 'one');
+  assert.equal(out.channels[1].name, 'Named');
+});
+
+test('parseM3U dedupes by URL and caps the list', () => {
+  const dup = '#EXTINF:-1,A\nhttp://d.example/x\n#EXTINF:-1,B\nhttp://d.example/x\n';
+  assert.equal(parseM3U(dup).count, 1);
+
+  const many = Array.from({ length: MAX_CHANNELS + 50 }, (_, i) =>
+    `#EXTINF:-1,Ch ${i}\nhttp://c.example/${i}`).join('\n');
+  const out = parseM3U(many);
+  assert.equal(out.ok, true);
+  assert.equal(out.count, MAX_CHANNELS);
+});
+
+test('parseM3U rejects empty or channel-less input', () => {
+  assert.equal(parseM3U('').ok, false);
+  assert.equal(parseM3U('#EXTM3U\n#nothing here').ok, false);
+});
+
+test('stripDecorations removes country prefix, quality tags and emoji noise', () => {
+  assert.equal(stripDecorations('US| FOX SPORTS UHD'), 'FOX SPORTS');
+  assert.equal(stripDecorations('CA: TSN4 HD'), 'TSN4');
+  assert.equal(stripDecorations('US| CA: ESPN FHD 1080'), 'ESPN');
+  assert.equal(stripDecorations('FOX ⚡'), 'FOX');
+  assert.equal(stripDecorations('ESPN'), 'ESPN');
+  assert.equal(stripDecorations('TS4: Something'), 'TS4: Something'); // TS4 not a country code
+});
+
+test('networkBugFor collapses decorations into the shared bug space', () => {
+  assert.equal(networkBugFor('US| TSN4 HD'), 'TSN4');
+  assert.equal(networkBugFor('fox sports 1'), 'FS1');
+  assert.equal(networkBugFor('Sportsnet One'), 'SN 1');
+  assert.equal(networkBugFor('CA: sn 3 fhd'), 'SN 3');
+});
+
+test('qualityRank prefers UHD over HD over untagged over SD', () => {
+  assert.ok(qualityRank('X UHD') < qualityRank('X HD'));
+  assert.ok(qualityRank('X 4K') < qualityRank('X FHD'));
+  assert.ok(qualityRank('X HDR') < qualityRank('X FHD'));
+  assert.ok(qualityRank('X HD') < qualityRank('X SD'));
+  assert.ok(qualityRank('X HD') < qualityRank('X'));
+});
+
+test('matchChannels: network match beats team-named channel', () => {
+  const chans = [
+    { name: 'ESPN HD', url: 'http://p/e1', group: '' },
+    { name: 'Toronto Maple Leafs TV', url: 'http://p/t1', group: '' },
+  ];
+  const got = matchChannels(ev(['ESPN']), chans);
+  assert.equal(got.length, 2);
+  assert.equal(got[0].reason, 'network');
+  assert.equal(got[0].name, 'ESPN HD');
+  assert.equal(got[1].reason, 'team');
+});
+
+test('matchChannels: quality tiebreak inside a network tier', () => {
+  const chans = [
+    { name: 'US| FOX SD', url: 'http://p/sd', group: '' },
+    { name: 'CA: FOX UHD', url: 'http://p/uhd', group: '' },
+  ];
+  const got = matchChannels(ev(['FOX']), chans);
+  assert.equal(got[0].name, 'CA: FOX UHD');
+});
+
+test('matchChannels: preferred channel jumps the queue and is flagged', () => {
+  const chans = [
+    { name: 'US| TSN4 UHD', url: 'http://p/uhd', group: '' },
+    { name: 'TSN4 SD', url: 'http://p/sd', group: '' },
+  ];
+  const got = matchChannels(ev(['TSN4']), chans, { preferred: { TSN4: 'TSN4 SD' } });
+  assert.equal(got[0].name, 'TSN4 SD');
+  assert.equal(got[0].preferred, true);
+  assert.equal(got[1].preferred, false);
+});
+
+test('matchChannels: full team name, abbr and city tiers', () => {
+  const chans = [
+    { name: 'Toronto CityTV', url: 'http://p/city', group: '' },        // city tier only
+    { name: 'Philadelphia Phillies Feed', url: 'http://p/philly', group: '' }, // no match
+    { name: 'Maple Leafs Home', url: 'http://p/leafs', group: '' },     // city? no — 'maple' token, full? no
+  ];
+  // 'Toronto Maple Leafs' away: full name must hit a channel containing it
+  const withFull = [{ name: 'Toronto Maple Leafs Game', url: 'http://p/full', group: '' }];
+  assert.equal(matchChannels(ev([]), withFull)[0].reason, 'team');
+  // city tier
+  const city = matchChannels(ev([]), chans);
+  assert.ok(city.some((m) => m.name === 'Toronto CityTV' && m.reason === 'team'));
+  // abbr tier — 'TOR' token (after 4K is stripped)
+  const abbrChans = [{ name: 'TOR 4K', url: 'http://p/tor', group: '' }];
+  const abbrGot = matchChannels(ev([]), abbrChans);
+  assert.equal(abbrGot.length, 1);
+  assert.equal(abbrGot[0].reason, 'team');
+  // no false positive on unrelated channel
+  assert.ok(!city.some((m) => m.url === 'http://p/philly'));
+});
+
+test('matchChannels: dedupes a channel matched via two bugs, honours limit', () => {
+  const chans = [{ name: 'ESPN HD', url: 'http://p/e', group: '' }];
+  const got = matchChannels(ev(['ESPN', 'ESPN2']), chans); // 'ESPN HD' → bug ESPN only
+  assert.equal(got.length, 1);
+
+  const many = Array.from({ length: 12 }, (_, i) => ({ name: `ESPN feed ${i}`, url: `http://p/${i}`, group: '' }))
+    .map((c) => ({ ...c, name: c.name.replace(/feed \d/, 'HD') }));
+  // 'ESPN HD' normalizes to ESPN for all → 12 candidates, limited to 6
+  assert.equal(matchChannels(ev(['ESPN']), many, { limit: 6 }).length, 6);
+});
+
+test('matchChannels: empty inputs are safe', () => {
+  assert.deepEqual(matchChannels(ev(['ESPN']), []), []);
+  assert.deepEqual(matchChannels(ev([]), [{ name: 'ESPN', url: 'u', group: '' }]), []);
+  assert.deepEqual(matchChannels(null, [{ name: 'ESPN', url: 'u', group: '' }]), []);
+});
+
+test('buildChannelIndex is reusable across calls (import once, match per game)', () => {
+  const chans = [
+    { name: 'US| FOX UHD', url: 'http://p/1', group: '' },
+    { name: 'FOX', url: 'http://p/2', group: '' },
+  ];
+  const index = buildChannelIndex(chans);
+  const got = matchChannels(ev(['FOX']), chans, { index });
+  assert.equal(got.length, 2);
+  assert.equal(got[0].name, 'US| FOX UHD'); // quality tiebreak still applies
+});


### PR DESCRIPTION
## Why this exists

Core Line shows live game scores but has no way to watch them. Users with IPTV subscriptions already have the channels — they just need the connection between "this game is on ESPN" and "I have ESPN in my playlist." This adds ScoreBox-style channel matching: import an M3U playlist once, and every game card shows which of your channels carry it, with one-tap handoff to an external player.

## What changed

Added 2 new files, modified 8 existing (10 files total, +909 lines):

- **`ticker/lib/playlist.mjs`** (295 lines) — M3U parser, channel index builder, game→channel matcher with tiered scoring (network bug > full team name > abbreviation > city), quality tiebreak (UHD > HDR > FHD > HD), 4000-channel cap
- **`ticker/tests/playlist.test.mjs`** (172 lines) — 15 tests covering all matching tiers, dedup, limits, edge cases
- **`ticker/public/js/app.js`** — Game Detail modal lifecycle, channel rendering, playlist import/clear actions, web fallback
- **`ticker/public/js/state.js`** — Playlist metadata persistence, separate localStorage key for channel data
- **`ticker/public/js/tv.js`** — D-pad focus constrained to modal when open, back-button closes detail first
- **`ticker/public/css/app.css`** — Game Detail modal styles (TV-aware sizing, reduced-motion support)
- **`ticker/public/index.html`** — Channels settings panel (M3U URL input, import/clear), game detail modal container
- **`ticker/server.mjs`** — `/api/playlist` proxy endpoint with SSRF guard (reuses `isSafeFeedUrl`)
- **`ticker/android/.../LineBridge.kt`** — `openStream(url)` JS bridge method
- **`ticker/android/.../MainActivity.kt`** — `openStream(url)` launches external player via `Intent.ACTION_VIEW`

## Verification

- [x] `cd ticker && npm test` — 112 tests pass (15 new playlist tests + 97 existing)
- [ ] No Android SDK in environment — APK build unverified
- [ ] Not tested on device or in browser (no dev server run)

```
112 pass, 0 fail
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJbpQkj9fcYQq4sLMHkjVQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJbpQkj9fcYQq4sLMHkjVQ)_