### PR TITLE
chore: bump Core Line to v1.3.0 (versionCode 6)

### DIFF
--- a/ticker/android/app/build.gradle.kts
+++ b/ticker/android/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
         applicationId = "dev.corebuilds.line"
         minSdk = 24
         targetSdk = 34
-        versionCode = 5
-        versionName = "1.2.0"
+        versionCode = 6
+        versionName = "1.3.0"
     }
 
     signingConfigs {

--- a/ticker/package.json
+++ b/ticker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "core-line",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "type": "module",
   "description": "Core Line — sports and channel RSS ticker for Android, TV, and the web",


### PR DESCRIPTION
## Why this exists

Marks the Core Line release after the ScoreBox-style IPTV channel matching feature landed. The version bump lets the tag and signed release build proceed.

## What changed

Bumped `ticker/android/app/build.gradle.kts` versionCode 5→6, versionName "1.2.0"→"1.3.0". Updated `ticker/package.json` version to match.

## Verification

- [x] `npm test` in `ticker/` — 112 tests pass
- [x] No Android SDK in environment — APK build is unverified locally (CI will confirm)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJbpQkj9fcYQq4sLMHkjVQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJbpQkj9fcYQq4sLMHkjVQ)_