### PR TITLE
fix(iconpack): in-app UI rework — focus/selection, copy bugs, tokenised spacing

### DIFF
--- a/tools/check_ui_resources.py
+++ b/tools/check_ui_resources.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Static check for the Core Builds in-app UI resources.
+
+There is no Android SDK in this environment, so `assembleDebug` cannot run.
+This does the part of resource linking that actually catches mistakes:
+
+  1. every modified XML file is well-formed
+  2. every @dimen/@color/@drawable/@string/@array reference in app/ and pop/
+     resolves to a declared resource in that same module
+  3. every R.id / R.string / R.drawable referenced from the shared Kotlin
+     exists in the layouts and values of the module that compiles it
+  4. every @+id declared in a layout is unique within that layout
+
+Exits non-zero on the first class of failure, listing all of them.
+"""
+from __future__ import annotations
+
+import re
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+ANDROID = "{http://schemas.android.com/apk/res/android}"
+
+# Pop compiles ../app/src/main/java, so its Kotlin must resolve against pop/.
+MODULES = {
+    "app": ROOT / "app" / "src" / "main",
+    "pop": ROOT / "pop" / "src" / "main",
+}
+KOTLIN = ROOT / "app" / "src" / "main" / "java" / "tv" / "corebuilds" / "iconpack"
+
+FAIL: list[str] = []
+
+
+def fail(msg: str) -> None:
+    FAIL.append(msg)
+
+
+def declared_resources(res: Path) -> dict[str, set[str]]:
+    """Collect resource names declared by a module's res/ tree."""
+    out: dict[str, set[str]] = {
+        "dimen": set(), "color": set(), "drawable": set(),
+        "string": set(), "array": set(), "style": set(),
+        "string-array": set(), "integer-array": set(),
+    }
+    for values in sorted(res.glob("values*/*.xml")):
+        try:
+            root = ET.parse(values).getroot()
+        except ET.ParseError as e:
+            fail(f"{values.relative_to(ROOT)}: not well-formed ({e})")
+            continue
+        for child in root:
+            tag = child.tag
+            name = child.get("name")
+            if not name:
+                continue
+            if tag == "string":
+                out["string"].add(name)
+            elif tag == "color":
+                out["color"].add(name)
+            elif tag == "dimen":
+                out["dimen"].add(name)
+            elif tag == "style":
+                out["style"].add(name)
+            elif tag in ("string-array", "integer-array", "array"):
+                out["array"].add(name)
+                out[tag].add(name)
+    # File-based resources.
+    for d in res.glob("drawable*"):
+        if d.is_dir():
+            for f in d.iterdir():
+                if f.is_file():
+                    out["drawable"].add(f.stem)
+    for d in res.glob("mipmap*"):
+        if d.is_dir():
+            for f in d.iterdir():
+                if f.is_file():
+                    out["drawable"].add(f.stem)
+    # res/color/*.xml are color state lists, referenced as @color/name.
+    cdir = res / "color"
+    if cdir.is_dir():
+        for f in cdir.iterdir():
+            if f.is_file():
+                out["color"].add(f.stem)
+    return out
+
+
+REF = re.compile(r'"@(?:\+)?(dimen|color|drawable|string|array|style)/([A-Za-z0-9_.]+)"')
+# Framework / support refs we must not try to resolve locally.
+SKIP_PREFIX = ("android:", "attr/")
+
+
+def check_refs(path: Path, res: Path, have: dict[str, set[str]]) -> None:
+    text = path.read_text(encoding="utf-8")
+    for kind, name in REF.findall(text):
+        if name.startswith(SKIP_PREFIX):
+            continue
+        # @style/Theme.* may be an AppCompat parent we don't declare.
+        if kind == "style" and "." in name:
+            continue
+        if name not in have.get(kind, set()):
+            fail(f"{path.relative_to(ROOT)}: @{kind}/{name} does not resolve in "
+                 f"{path.parent.parent.parent.parent.name}/")
+
+
+def layout_ids(path: Path) -> set[str]:
+    root = ET.parse(path).getroot()
+    ids: list[str] = []
+    for el in root.iter():
+        v = el.get(f"{ANDROID}id")
+        if v and v.startswith("@+id/"):
+            ids.append(v[len("@+id/"):])
+    dupes = {i for i in ids if ids.count(i) > 1}
+    if dupes:
+        fail(f"{path.relative_to(ROOT)}: duplicate @+id {sorted(dupes)}")
+    return set(ids)
+
+
+def main() -> int:
+    all_ids: dict[str, set[str]] = {}
+    for mod, main in MODULES.items():
+        res = main / "res"
+        if not res.is_dir():
+            fail(f"{mod}: no res/ tree")
+            continue
+        have = declared_resources(res)
+
+        for xml in sorted(res.rglob("*.xml")):
+            try:
+                ET.parse(xml)
+            except ET.ParseError as e:
+                fail(f"{xml.relative_to(ROOT)}: not well-formed ({e})")
+                continue
+            check_refs(xml, res, have)
+            if xml.parent.name == "layout":
+                all_ids.setdefault(mod, set()).update(layout_ids(xml))
+
+        # Kotlin references. Both modules compile this same source tree.
+        for kt in sorted(KOTLIN.glob("*.kt")):
+            src = kt.read_text(encoding="utf-8")
+            for kind in ("id", "string", "drawable", "dimen", "color", "array"):
+                for name in re.findall(rf"R\.{kind}\.([A-Za-z0-9_]+)", src):
+                    if kind == "id":
+                        if name not in all_ids.get(mod, set()):
+                            fail(f"{kt.name} ({mod}): R.id.{name} is not declared "
+                                 f"in any {mod} layout")
+                    elif name not in have.get(
+                            "string" if kind == "string" else
+                            "drawable" if kind == "drawable" else
+                            "dimen" if kind == "dimen" else
+                            "color" if kind == "color" else "array", set()):
+                        fail(f"{kt.name} ({mod}): R.{kind}.{name} does not resolve")
+
+    if FAIL:
+        print(f"FAILED — {len(FAIL)} problem(s):\n")
+        for f in FAIL:
+            print("  \u2717 " + f)
+        return 1
+    print("OK — XML well-formed, every resource reference resolves in both "
+          "modules, every R.* in the shared Kotlin exists, no duplicate ids.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## App

- [x] Icon pack
- [ ] Pixel Neon icon pack
- [ ] Core Line
- [ ] Core Shift
- [ ] Core Doctor
- [ ] Core Motion
- [ ] Docs / CI / suite

## Why this exists

Three shipping copy bugs, a focus/selection visual that was indistinguishable at TV distance, content that jumped on every D-pad press, raw pixel literals in layouts, and no empty state for zero-match filters.

## What changed (name the number)

**3 copy bugs fixed**
- `strings.xml:6` hardcoded "pack v1.5.1" since that release — now reads `BuildConfig.VERSION_NAME`
- Dead wallpaper string deleted (wrong count, unused code path)
- "4K" removed from wallpaper subtitle (10 of 50 walls are 1376x768)

**Focus and selection separated** — focus is now a 3dp ring with 3dp background gap and outer glow; activated chip is a filled CTA gradient with `cb_cta_ink` text (new `res/color/cb_chip_text.xml` selector). Previously both were thin cyan strokes, indistinguishable at 3m.

**Focus no longer moves artwork** — `bg_card` inset was focus-state only, causing a 2dp content jump on every key press. Both states now carry the same `cb_focus_inset`.

**Type, spacing and targets tokenised** — new `values/dimens.xml`, no raw literals remain in layouts. Type floor 12sp (was 10sp). Titles drop serif for sans at 42sp. Focusable controls reach 48dp floor via `minHeight`.

**Filtering stops rebinding 925 rows** — `IconAdapter` uses `DiffUtil` + stable ids. `ChipAdapter.select(key)` fires targeted `notifyItemChanged` (was `notifyDataSetChanged`, which also dropped focus).

**Empty state added** for zero-match filters (was blank grid, no message, no undo).

**Off-palette ripple removed** — `?android:attr/selectableItemBackground` replaced with `cb_ripple` via `colorControlHighlight` in themes.

**46 files** changed across app/ and pop/ modules.

## Verification

- [x] `python tools/check_suite_truth.py`
- [x] `python tools/audit_contract.py`

Icon pack bump:
- [ ] `app/build.gradle.kts` versionName + versionCode — no version bump (bug fix)
- [ ] `tools/catalog.json` meta.version — no version bump
- [ ] `Latestrelease/version.json` — no version bump
- [ ] `python tools/build_icons.py` — icons not touched
- [ ] `python tools/build_banners.py` — banners not touched
- [ ] `python tools/build_branding.py` — branding not touched
- [ ] `python tools/build_brand_preview.py` — branding not touched
- [x] `python tools/validate.py` — `24769 checks passed across 925 icons`
- [x] `python tools/validate_pop.py` — `13892 checks` (up from 13890: two new mirrored files registered in `build_pop.py`)
- [x] 149 unit tests passed (993 subtests)
- [x] `python tools/check_ui_resources.py` — new static check: XML well-formed, every `@dimen/@color/@drawable/@string` resolves in both modules, every `R.*` in shared Kotlin exists, no duplicate `@+id`

## Notes / unverified

- No Android SDK in this environment — `./gradlew :app:assembleDebug` not run. Layout inflation, real D-pad traversal, and rendered type are unchecked. CI covers these.
- No device render. The companion mockups are CSS at 1920x1080, not Android inflation. Spacing and focus legibility need eyes on a panel.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJbpQkj9fcYQq4sLMHkjVQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJbpQkj9fcYQq4sLMHkjVQ)_