### PR TITLE
ci(pixel-neon): gate every generated asset, not five hand-listed paths

### DIFF
--- a/.github/workflows/pixel-neon-apk.yml
+++ b/.github/workflows/pixel-neon-apk.yml
@@ -47,15 +47,27 @@ jobs:
         run: python tools/validate_pixel_neon.py
 
       - name: Verify generated assets are committed
-        # Scoped like the classic and Pop packs: mapping/definitional files
-        # are gated byte-exactly, plus every raster we have proven stable
-        # across environments. The one exemption is docs/preview.png: it is
-        # the only asset rendered through FreeType text, whose hinting pulls
-        # in the OS libm — pixel output legitimately varies by rasteriser
-        # stack ("PNG bytes move with the rasteriser's version"). The preview
-        # stays committed and human-reviewed; it is not a shipping asset.
+        # Gate everything the two generators above write, the way the classic
+        # pack gates '*.png' globally. The previous scope named five paths and
+        # left out res/drawable-nodpi — the 1800+ shipping rasters — so a stale
+        # icon passed CI silently: that is how the blue `sevenplus` tile
+        # survived the v1.8.8 brand-colour remediation and shipped until
+        # v1.8.10 regenerated it. res/mipmap-* and res/layout were ungated for
+        # the same reason. An allowlist of generated paths cannot help here,
+        # because the failure mode is a path nobody remembered to add.
+        #
+        # Hand-written sources under pixel-neon/ never trip this: the check
+        # runs after the generators and reports only what they rewrote
+        # relative to the commit under test.
+        #
+        # The one exemption stays docs/preview.png: it is the only asset
+        # rendered through FreeType text, whose hinting pulls in the OS libm —
+        # pixel output legitimately varies by rasteriser stack ("PNG bytes
+        # move with the rasteriser's version"). It stays committed and
+        # human-reviewed; it is not a shipping asset. Everything else here
+        # reproduces byte-identically.
         run: |
-          DRIFT=$(git status --porcelain -- PixelNeonWallpapers pixel-neon/docs pixel-neon/app/src/main/assets pixel-neon/app/src/main/res/xml pixel-neon/app/src/main/res/values/icon_pack.xml ':(exclude)pixel-neon/docs/preview.png' | grep -v '^?? ' || true)
+          DRIFT=$(git status --porcelain -- PixelNeonWallpapers pixel-neon ':(exclude)pixel-neon/docs/preview.png' | grep -v '^?? ' || true)
           if [ -n "$DRIFT" ]; then
             echo "::error::Pixel Neon generated assets drift from the wallpaper/icon sources. Run: python tools/build_pixel_neon_wallpapers.py && python tools/build_pixel_neon.py"
             # One annotation per drifted file so the diff is readable without


### PR DESCRIPTION
## App

- [ ] Icon pack
- [x] Pixel Neon icon pack
- [ ] Core Line
- [ ] Core Shift
- [ ] Core Doctor
- [ ] Core Motion
- [x] Docs / CI / suite

## Why this exists

This is the root cause of the "7plus displays red but applies blue" report.

`#97` fixed the symptom by regenerating 68 stale Pixel Neon rasters. It did not fix the reason a stale raster could ship in the first place: **Pixel Neon's CI drift gate did not cover its shipping icons.**

Before `#97`, at `9e630eb3`:

| Asset | Colour |
|---|---|
| `pixel-neon/…/sevenplus.png` | `#0073F4` **blue** |
| `pixel-neon/…/sevenplus_banner.png` | `#0073F4` **blue** |
| `pixel-neon/…/seven_plus.png` | `#FF4D00` orange |

The catalog said red, so every catalog-driven surface *displayed* red while the PNG that actually reaches the launcher was still blue. It survived the v1.8.8 brand-colour remediation and kept shipping until v1.8.10 regenerated it — with CI green the whole time.

## What changed (name the number)

**1. One line of scope in `.github/workflows/pixel-neon-apk.yml`**

The check named five paths. The two generators it runs write **nine directories**:

| Directory | Files written | Was gated? |
|---|---|---|
| `res/drawable-nodpi` | **1851** | ❌ **no** |
| `res/mipmap-xxhdpi` | 2 | ❌ no |
| `res/mipmap-xhdpi` | 2 | ❌ no |
| `res/mipmap-anydpi-v26` | 2 | ❌ no |
| `res/layout` | 1 | ❌ no |
| `res/values` | 1 | ⚠️ only `icon_pack.xml` |
| `res/xml` | 3 | ✅ |
| `main/assets` | 2 | ✅ |
| `pixel-neon/docs` | 3 | ✅ |

`res/drawable-nodpi` is the shipping icon set. `res/mipmap-*` is the launcher icon.

```diff
-git status --porcelain -- PixelNeonWallpapers pixel-neon/docs pixel-neon/app/src/main/assets pixel-neon/app/src/main/res/xml pixel-neon/app/src/main/res/values/icon_pack.xml ':(exclude)pixel-neon/docs/preview.png'
+git status --porcelain -- PixelNeonWallpapers pixel-neon ':(exclude)pixel-neon/docs/preview.png'
```

Widened to the whole tree, matching how the classic pack gates `'*.png'` globally. An allowlist of generated paths can't fix this class of bug — the failure mode *is* a path nobody remembered to add.

**2. Comment rewritten** to record why the scope is broad, so it doesn't get narrowed back.

## Verification

Reproduced against the actual historical bug — restored the pre-v1.8.10 blue `sevenplus.png` and ran each scope's exact command:

| Scenario | Old scope | New scope |
|---|---|---|
| Clean tree | empty (pass) | **empty (pass)** — no false positive |
| Blue `sevenplus.png` restored | **empty — ships silently** | **caught** ✅ |
| `docs/preview.png` modified | empty (exempt) | **empty (exempt)** — still honoured |

- [x] Safe to gate: regenerating Pixel Neon here leaves `res/drawable-nodpi` at **0 drift across all 1851 files**; only `docs/preview.png` varies, and it keeps its exemption
- [x] `python tools/build_pixel_neon_wallpapers.py && python tools/build_pixel_neon.py` — whole `pixel-neon/` tree clean afterwards apart from `docs/preview.png`
- [x] `python tools/validate_pixel_neon.py` — 925 icons · 1099 components · 12520 checks
- [x] Workflow YAML parses; step body unchanged apart from the scope

## Notes / unverified

- Hand-written sources under `pixel-neon/` don't trip the wider gate: the check runs *after* the generators and reports only what they rewrote relative to the commit under test
- `docs/preview.png` stays exempt — FreeType text rendering makes its bytes rasteriser-dependent, and it isn't a shipping asset
- Independent of #98 (branched from `main`, no file overlap) — mergeable in either order
- Not audited here: whether the classic and Pop gates have equivalent blind spots. Both looked broader (classic gates `'*.png'` globally), but I only verified Pixel Neon end to end

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJbpQkj9fcYQq4sLMHkjVQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJbpQkj9fcYQq4sLMHkjVQ)_