### PR TITLE
fix(iconpack): lock 7plus/AdGuard/Discovery identity, hold AGENTS.md to suite truth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 
 | Product | Path | Package ID | Version | Downloader / stable tag |
 |---|---|---|---:|---|
-| Core Builds Icon Pack | `app/` with repo-root Gradle | `tv.corebuilds.iconpack` | `1.8.8` | `5270601` / `iconpack` |
+| Core Builds Icon Pack | `app/` with repo-root Gradle | `tv.corebuilds.iconpack` | `1.8.10` | `5270601` / `iconpack` |
 | Core Builds Pixel Neon | `pixel-neon/` | `tv.corebuilds.pixelneon` | `0.1.0` | `[USER TO SUPPLY]` / `pixel-neon` |
 | Core Builds Pop | `pop/` with repo-root Gradle | `tv.corebuilds.iconpack.pop` | `1.0.0` | `[USER TO SUPPLY]` / `pop` |
 | Core Line | `ticker/` + `ticker/android/` | `dev.corebuilds.line` | `1.3.0` | `7375676` / `coreline` |
@@ -73,7 +73,7 @@ Pop wallpapers are separate and rarely need rebuilding:
 python tools/build_pop_wallpapers.py  # ~70 s
 ```
 
-`Wallpapers/manifest.json` belongs to the classic pack and stays at 50 entries. Pop uses `Wallpapers/pop-manifest.json`. The two collections are asserted disjoint.
+`Wallpapers/manifest.json` belongs to the classic pack and currently has 58 entries. Pop uses `Wallpapers/pop-manifest.json`. The two collections are asserted disjoint.
 
 ## Truth gates
 
@@ -85,7 +85,7 @@ python tools/check_suite_truth.py
 python tools/audit_contract.py
 ```
 
-`check_suite_truth.py` fails stale README/agent/doc claims, catalog/Gradle/version metadata drift, missing stamped README block, and the `line-v*` trap. Core Line's prefix is `coreline-v*`.
+`check_suite_truth.py` fails stale README/agent/doc claims, catalog/Gradle/version metadata drift, an AGENTS.md suite-table or wallpaper-count mismatch, missing stamped README block, and the `line-v*` trap. Core Line's prefix is `coreline-v*`.
 
 ## Product verification shortcuts
 

--- a/tests/test_icon_identity.py
+++ b/tests/test_icon_identity.py
@@ -52,6 +52,9 @@ class IdentityTests(unittest.TestCase):
         groups = [
             ("iplayer", "bbc_iplayer", "bbciplayer"),
             ("ninenow", "ninenow_2"),
+            ("sevenplus", "seven_plus"),
+            ("adguard", "adguard_2"),
+            ("discovery", "discoveryplus"),
             ("syncler", "syncler_2", "syncler_beta"),
             ("weyd", "weyd_2"),
             ("smarttube", "smarttubenext"),

--- a/tools/catalog.json
+++ b/tools/catalog.json
@@ -49,6 +49,7 @@
         "au.com.seven.inferno/.MainActivity"
       ],
       "category": "VOD",
+      "brand": "7plus",
       "color_source": "sampled from the official 7plus logo",
       "color_reviewed": "2026-09-08",
       "color_note": "sampled from the official 7plus logo (Seven Network red origami 7 + red wordmark) 2026-09-08; replaces pre-provenance blue #0072CE"
@@ -213,6 +214,7 @@
         "com.adguard.android/com.adguard.android.ui.activity.SplashActivity"
       ],
       "category": "APP",
+      "brand": "adguard",
       "color_source": "brand reference (pre-provenance, unverified)",
       "color_reviewed": null
     },
@@ -225,6 +227,7 @@
         "com.adguard.vpn/com.adguard.vpn.ui.routing_activity.SplashActivity"
       ],
       "category": "VPN",
+      "brand": "adguard",
       "color_source": "brand reference (pre-provenance, unverified)",
       "color_reviewed": null
     },
@@ -2260,6 +2263,7 @@
         "com.discovery.dplay/com.wbd.beam.BeamActivity"
       ],
       "category": "VOD",
+      "brand": "discovery",
       "color_source": "brand reference (pre-provenance, unverified)",
       "color_reviewed": null
     },
@@ -2272,6 +2276,7 @@
         "com.discovery.discoveryplus.mobile/com.wbd.beam.BeamActivity"
       ],
       "category": "VOD",
+      "brand": "discovery",
       "color_source": "brand reference (pre-provenance, unverified)",
       "color_reviewed": null
     },
@@ -9196,6 +9201,7 @@
         "com.swm.live/au.com.seven.inferno.ui.tv.setup.SetupTvActivity"
       ],
       "category": "VOD",
+      "brand": "7plus",
       "unverified": [
         "com.swm.live/au.com.seven.inferno.ui.setup.SetupActivity",
         "com.swm.live/au.com.seven.inferno.ui.tv.setup.SetupTvActivity"

--- a/tools/check_suite_truth.py
+++ b/tools/check_suite_truth.py
@@ -157,6 +157,34 @@ def check_line_v_trap() -> None:
         fail("line-v* release prefix trap present outside docs warning: " + ", ".join(sorted(set(offenders))))
 
 
+def check_agents_guide(suite: dict) -> None:
+    """AGENTS.md is outside the README stamp, so its suite table and wallpaper
+    count can rot without any other gate noticing. Hold them to suite.json and
+    Wallpapers/manifest.json the same way the README stamp is held."""
+    agents = read("AGENTS.md")
+    by_id = {app["applicationId"]: (key, app["versionName"])
+             for key, app in suite["apps"].items()}
+    seen: set[str] = set()
+    for pkg, ver in re.findall(
+        r"^\| [^|\n]+\| [^|\n]+\| `([a-zA-Z0-9._]+)` \| `([^`]+)` \|",
+        agents,
+        flags=re.M,
+    ):
+        if pkg not in by_id:
+            fail(f"AGENTS.md suite table has unknown package {pkg}")
+        key, expected = by_id[pkg]
+        if ver != expected:
+            fail(f"AGENTS.md suite table {key} version {ver} != suite.json {expected}")
+        seen.add(pkg)
+    missing = [key for key, app in suite["apps"].items()
+               if app["applicationId"] not in seen]
+    if missing:
+        fail("AGENTS.md suite table missing apps: " + ", ".join(missing))
+    count = json.loads(read("Wallpapers/manifest.json"))["count"]
+    if not re.search(rf"currently has {count} entries", agents):
+        fail(f"AGENTS.md must state classic wallpaper count as 'currently has {count} entries'")
+
+
 def main() -> int:
     suite = check_suite_json()
     check_iconpack_truth(suite)
@@ -164,6 +192,7 @@ def main() -> int:
     check_readme_stamp(suite)
     check_stale_claims()
     check_line_v_trap()
+    check_agents_guide(suite)
     print("suite truth checks passed")
     return 0
 


### PR DESCRIPTION
## App

- [x] Icon pack
- [ ] Pixel Neon icon pack
- [ ] Core Line
- [ ] Core Shift
- [ ] Core Doctor
- [ ] Core Motion
- [x] Docs / CI / suite

## Why this exists

Post-1.8.10 leftovers that do not need a device, a generator run, or a version bump.

`seven_plus` drifted to orange `tile_S` once because nothing grouped it with `sevenplus`. AdGuard/AdGuard VPN and Discovery/Discovery+ already share glyph and accent the same way, and would drift the same way. AGENTS.md still said pack 1.8.8 and 50 wallpapers; `check_suite_truth.py` never looked at that table, only a hardcoded stale-needle list.

## What changed (name the number)

**1. Three brand groups** in `tools/catalog.json` (6 entries, metadata only)
- `brand: "7plus"` on `sevenplus` / `seven_plus`
- `brand: "adguard"` on `adguard` / `adguard_2`
- `brand: "discovery"` on `discovery` / `discoveryplus`

**2. Identity test** — those three tuples join `test_known_variants_are_in_the_same_identity_group`, so a future colour/glyph split fails CI the way 9Now already does.

**3. AGENTS.md** — suite table `1.8.8` → `1.8.10`; wallpaper rule `stays at 50` → `currently has 58`.

**4. `check_suite_truth.py`** — new `check_agents_guide`: parses the suite table against `suite.json` applicationId/versionName, and requires the wallpaper sentence to match `Wallpapers/manifest.json` count. Restoring the pre-fix `1.8.8` / `50` claims fails the gate; clean tree passes.

No artwork, XML, PNG, or version bump. Generators do not need a re-run.

## Verification

- [x] `python tools/check_suite_truth.py` — suite truth checks passed
- [x] Negative: stale AGENTS `1.8.8` and `stays at 50 entries` both fail the new check
- [x] `python tests/test_icon_identity.py IdentityTests.test_known_variants_are_in_the_same_identity_group IdentityTests.test_catalog_accepts_every_icon IdentityTests.test_same_brand_must_not_drift_in_colour_or_glyph` — OK
- [ ] `python tools/audit_contract.py` — not run (no expected overlap; local tree is a sparse checkout)
- [ ] Full `test_icon_identity.py` — 2 pre-existing errors here (`resvg_py` / `cairosvg` not installed); the three tests this PR touches do not rasterise

## Notes / unverified

Not in this PR (need a device or a full pack rebuild):
- Live 7plus Leanback activity on `com.swm.live` (only setup activities are mapped; paste `adb shell cmd package resolve-activity --brief com.swm.live`)
- WeatherBug (`com.weatherbug.firetv`) still rides `streamflix_2` — splitting it is a new catalog icon + generator run
- Duplicate display names that do **not** share glyph/colour (Jawwy TV, Launcher Manager, Streamflix, ERTFLIX) — those are design calls, not identity bugs
