### PR TITLE
fix(tv): wallpaper chips drop highlight on select, tiles never take D-pad focus

### DIFF
--- a/app/src/main/java/tv/corebuilds/iconpack/WallpaperAdapter.kt
+++ b/app/src/main/java/tv/corebuilds/iconpack/WallpaperAdapter.kt
@@ -7,6 +7,7 @@ import android.os.Looper
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.animation.DecelerateInterpolator
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
@@ -53,6 +54,8 @@ class WallpaperAdapter(
         }
         holder.label.text = item.title
         holder.itemView.contentDescription = item.title
+        holder.itemView.isFocusable = true
+        holder.itemView.isFocusableInTouchMode = true
 
         val isSelected = selected.contains(item.cacheName)
         holder.ring.visibility = if (selectionMode && isSelected) View.VISIBLE else View.GONE
@@ -64,6 +67,25 @@ class WallpaperAdapter(
             if (!selectionMode) enterSelectionMode()
             toggle(item)
             true
+        }
+
+        holder.itemView.animate().cancel()
+        holder.itemView.scaleX = 1f
+        holder.itemView.scaleY = 1f
+        holder.itemView.elevation = 0f
+        holder.itemView.setOnFocusChangeListener { view, focused ->
+            view.animate().cancel()
+            view.animate()
+                .scaleX(if (focused) 1.035f else 1f)
+                .scaleY(if (focused) 1.035f else 1f)
+                .setDuration(160L)
+                .setInterpolator(DecelerateInterpolator())
+                .start()
+            view.animate()
+                .translationZ(if (focused) 8f else 0f)
+                .setDuration(160L)
+                .setInterpolator(DecelerateInterpolator())
+                .start()
         }
     }
 

--- a/app/src/main/java/tv/corebuilds/iconpack/WallpaperChipAdapter.kt
+++ b/app/src/main/java/tv/corebuilds/iconpack/WallpaperChipAdapter.kt
@@ -1,7 +1,9 @@
 package tv.corebuilds.iconpack
 
+import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import android.view.animation.DecelerateInterpolator
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 
@@ -9,15 +11,29 @@ import androidx.recyclerview.widget.RecyclerView
  * Category chips for the wallpaper browser. Same look as [ChipAdapter] but
  * keyed by a nullable String (null = "All") so it can't be confused with the
  * icon-pack adapter's non-null contract.
+ *
+ * Selection is applied with targeted notifyItemChanged calls rather than
+ * notifyDataSetChanged(). A full rebind here cancels the chip row's item
+ * animations and drops focus from the chip the user just pressed — on a D-pad
+ * that means the highlight vanishes on the press that was supposed to move it.
  */
 class WallpaperChipAdapter(
     private val labels: List<String>,
     private val keys: List<String?>,
-    private var selected: String?,
+    selected: String?,
     private val onPick: (String?) -> Unit
 ) : RecyclerView.Adapter<WallpaperChipAdapter.VH>() {
 
+    private var selectedKey: String? = selected
+
     class VH(val view: TextView) : RecyclerView.ViewHolder(view)
+
+    init {
+        setHasStableIds(true)
+    }
+
+    override fun getItemId(position: Int): Long =
+        (keys[position] ?: "\u0000").hashCode().toLong()
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): VH {
         val v = LayoutInflater.from(parent.context)
@@ -27,14 +43,62 @@ class WallpaperChipAdapter(
 
     override fun onBindViewHolder(holder: VH, position: Int) {
         val key = keys[position]
+        val selected = key == selectedKey
         holder.view.text = labels[position]
-        holder.view.isActivated = key == selected
-        holder.view.setOnClickListener {
-            selected = key
-            notifyDataSetChanged()
-            onPick(key)
+        holder.view.isActivated = selected
+        holder.view.isSelected = selected
+        holder.view.contentDescription =
+            "${labels[position]}, filter${if (selected) ", selected" else ""}"
+        // item_chip.xml is shared with the icon grid and points nextFocus at
+        // apply_button / grid, which do not exist on this screen. Override so
+        // Up collapses through the (often GONE) selection bar to Back, and
+        // Down lands on the wallpaper grid.
+        holder.view.nextFocusUpId = R.id.wp_selection_bar
+        holder.view.nextFocusDownId = R.id.wp_grid
+        holder.view.setOnClickListener { select(key) }
+        holder.view.setOnKeyListener { view, keyCode, event ->
+            if (event.action != KeyEvent.ACTION_DOWN) return@setOnKeyListener false
+            val direction = when (keyCode) {
+                KeyEvent.KEYCODE_DPAD_LEFT -> -1
+                KeyEvent.KEYCODE_DPAD_RIGHT -> 1
+                else -> 0
+            }
+            if (direction == 0) return@setOnKeyListener false
+            val positionNow = holder.bindingAdapterPosition
+            if (positionNow == RecyclerView.NO_POSITION) return@setOnKeyListener false
+            val target = (view.parent as? RecyclerView)
+                ?.layoutManager
+                ?.findViewByPosition(positionNow + direction)
+            if (target != null) {
+                target.requestFocus()
+                true
+            } else {
+                false
+            }
+        }
+        holder.view.animate().cancel()
+        holder.view.scaleX = 1f
+        holder.view.scaleY = 1f
+        holder.view.setOnFocusChangeListener { view, focused ->
+            view.animate().cancel()
+            view.animate()
+                .scaleX(if (focused) 1.04f else 1f)
+                .scaleY(if (focused) 1.04f else 1f)
+                .setDuration(140L)
+                .setInterpolator(DecelerateInterpolator())
+                .start()
         }
     }
 
     override fun getItemCount() = keys.size
+
+    fun select(key: String?) {
+        if (key == selectedKey) return
+        val previous = keys.indexOf(selectedKey)
+        selectedKey = key
+        val next = keys.indexOf(key)
+        if (previous >= 0) notifyItemChanged(previous)
+        if (next >= 0) notifyItemChanged(next)
+        onPick(key)
+    }
 }

--- a/app/src/main/res/layout/item_wallpaper.xml
+++ b/app/src/main/res/layout/item_wallpaper.xml
@@ -4,25 +4,30 @@
   treatment as item_icon (Brand Guide §05). In selection mode a cyan frame
   marks chosen tiles.
 
-  No android:foreground ripple here. It pointed at
-  ?android:attr/selectableItemBackground, which resolves to the platform's grey
-  highlight — the only off-palette colour in the app — and it sat on this
-  FrameLayout while the focus ring is drawn on the inner card, so press and
-  focus highlighted two different rectangles. Press feedback now comes from the
-  theme's colorControlHighlight, in brand cyan, on the same surface as focus.
+  The ROOT is the focusable card. A previous revision put clickable/focusable
+  + bg_card on the inner LinearLayout and the click listener on this
+  FrameLayout, so D-pad highlight and OK landed on two different views —
+  the cyan ring never tracked the focused tile, and centre-press did nothing.
+  Press feedback comes from the theme's colorControlHighlight, in brand cyan,
+  on the same surface as focus. No platform selectableItemBackground: that
+  resolves to the grey highlight, the only off-palette colour in the app.
 -->
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:background="@drawable/bg_card"
+    android:clickable="true"
+    android:descendantFocusability="blocksDescendants"
+    android:focusable="true"
+    android:focusableInTouchMode="true"
+    android:minHeight="@dimen/cb_target_min"
     android:padding="0dp">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@drawable/bg_card"
-        android:clickable="true"
-        android:focusable="true"
-        android:focusableInTouchMode="true"
+        android:clickable="false"
+        android:focusable="false"
         android:gravity="center_horizontal"
         android:minHeight="@dimen/cb_target_min"
         android:orientation="vertical"

--- a/pixel-neon/app/src/main/java/tv/corebuilds/pixelneon/WallpaperAdapter.kt
+++ b/pixel-neon/app/src/main/java/tv/corebuilds/pixelneon/WallpaperAdapter.kt
@@ -7,6 +7,7 @@ import android.os.Looper
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.animation.DecelerateInterpolator
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
@@ -53,6 +54,8 @@ class WallpaperAdapter(
         }
         holder.label.text = item.title
         holder.itemView.contentDescription = item.title
+        holder.itemView.isFocusable = true
+        holder.itemView.isFocusableInTouchMode = true
 
         val isSelected = selected.contains(item.cacheName)
         holder.ring.visibility = if (selectionMode && isSelected) View.VISIBLE else View.GONE
@@ -64,6 +67,25 @@ class WallpaperAdapter(
             if (!selectionMode) enterSelectionMode()
             toggle(item)
             true
+        }
+
+        holder.itemView.animate().cancel()
+        holder.itemView.scaleX = 1f
+        holder.itemView.scaleY = 1f
+        holder.itemView.elevation = 0f
+        holder.itemView.setOnFocusChangeListener { view, focused ->
+            view.animate().cancel()
+            view.animate()
+                .scaleX(if (focused) 1.035f else 1f)
+                .scaleY(if (focused) 1.035f else 1f)
+                .setDuration(160L)
+                .setInterpolator(DecelerateInterpolator())
+                .start()
+            view.animate()
+                .translationZ(if (focused) 8f else 0f)
+                .setDuration(160L)
+                .setInterpolator(DecelerateInterpolator())
+                .start()
         }
     }
 

--- a/pixel-neon/app/src/main/java/tv/corebuilds/pixelneon/WallpaperChipAdapter.kt
+++ b/pixel-neon/app/src/main/java/tv/corebuilds/pixelneon/WallpaperChipAdapter.kt
@@ -1,7 +1,9 @@
 package tv.corebuilds.pixelneon
 
+import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import android.view.animation.DecelerateInterpolator
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 
@@ -9,15 +11,29 @@ import androidx.recyclerview.widget.RecyclerView
  * Category chips for the wallpaper browser. Same look as [ChipAdapter] but
  * keyed by a nullable String (null = "All") so it can't be confused with the
  * icon-pack adapter's non-null contract.
+ *
+ * Selection is applied with targeted notifyItemChanged calls rather than
+ * notifyDataSetChanged(). A full rebind here cancels the chip row's item
+ * animations and drops focus from the chip the user just pressed — on a D-pad
+ * that means the highlight vanishes on the press that was supposed to move it.
  */
 class WallpaperChipAdapter(
     private val labels: List<String>,
     private val keys: List<String?>,
-    private var selected: String?,
+    selected: String?,
     private val onPick: (String?) -> Unit
 ) : RecyclerView.Adapter<WallpaperChipAdapter.VH>() {
 
+    private var selectedKey: String? = selected
+
     class VH(val view: TextView) : RecyclerView.ViewHolder(view)
+
+    init {
+        setHasStableIds(true)
+    }
+
+    override fun getItemId(position: Int): Long =
+        (keys[position] ?: "\u0000").hashCode().toLong()
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): VH {
         val v = LayoutInflater.from(parent.context)
@@ -27,14 +43,58 @@ class WallpaperChipAdapter(
 
     override fun onBindViewHolder(holder: VH, position: Int) {
         val key = keys[position]
+        val selected = key == selectedKey
         holder.view.text = labels[position]
-        holder.view.isActivated = key == selected
-        holder.view.setOnClickListener {
-            selected = key
-            notifyDataSetChanged()
-            onPick(key)
+        holder.view.isActivated = selected
+        holder.view.isSelected = selected
+        holder.view.contentDescription =
+            "${labels[position]}, filter${if (selected) ", selected" else ""}"
+        holder.view.nextFocusUpId = R.id.wp_selection_bar
+        holder.view.nextFocusDownId = R.id.wp_grid
+        holder.view.setOnClickListener { select(key) }
+        holder.view.setOnKeyListener { view, keyCode, event ->
+            if (event.action != KeyEvent.ACTION_DOWN) return@setOnKeyListener false
+            val direction = when (keyCode) {
+                KeyEvent.KEYCODE_DPAD_LEFT -> -1
+                KeyEvent.KEYCODE_DPAD_RIGHT -> 1
+                else -> 0
+            }
+            if (direction == 0) return@setOnKeyListener false
+            val positionNow = holder.bindingAdapterPosition
+            if (positionNow == RecyclerView.NO_POSITION) return@setOnKeyListener false
+            val target = (view.parent as? RecyclerView)
+                ?.layoutManager
+                ?.findViewByPosition(positionNow + direction)
+            if (target != null) {
+                target.requestFocus()
+                true
+            } else {
+                false
+            }
+        }
+        holder.view.animate().cancel()
+        holder.view.scaleX = 1f
+        holder.view.scaleY = 1f
+        holder.view.setOnFocusChangeListener { view, focused ->
+            view.animate().cancel()
+            view.animate()
+                .scaleX(if (focused) 1.04f else 1f)
+                .scaleY(if (focused) 1.04f else 1f)
+                .setDuration(140L)
+                .setInterpolator(DecelerateInterpolator())
+                .start()
         }
     }
 
     override fun getItemCount() = keys.size
+
+    fun select(key: String?) {
+        if (key == selectedKey) return
+        val previous = keys.indexOf(selectedKey)
+        selectedKey = key
+        val next = keys.indexOf(key)
+        if (previous >= 0) notifyItemChanged(previous)
+        if (next >= 0) notifyItemChanged(next)
+        onPick(key)
+    }
 }

--- a/pixel-neon/app/src/main/res/layout/item_wallpaper.xml
+++ b/pixel-neon/app/src/main/res/layout/item_wallpaper.xml
@@ -1,45 +1,56 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- One wallpaper in the browser grid. 16:9 thumbnail on a glass card,
-     same focus treatment as item_icon (Brand Guide §05). In selection mode
-     a cyan ring marks chosen tiles. -->
+<!--
+  One wallpaper in the browser grid. 16:9 thumbnail on a glass card, same focus
+  treatment as item_icon (Brand Guide §05). In selection mode a cyan frame
+  marks chosen tiles.
+
+  The ROOT is the focusable card. A previous revision put clickable/focusable
+  + bg_card on the inner LinearLayout and the click listener on this
+  FrameLayout, so D-pad highlight and OK landed on two different views.
+  No platform selectableItemBackground: that resolves to the grey highlight.
+-->
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:foreground="?android:attr/selectableItemBackground"
+    android:background="@drawable/bg_card"
+    android:clickable="true"
+    android:descendantFocusability="blocksDescendants"
+    android:focusable="true"
+    android:focusableInTouchMode="true"
+    android:minHeight="@dimen/cb_target_min"
     android:padding="0dp">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@drawable/bg_card"
-        android:clickable="true"
-        android:focusable="true"
-        android:focusableInTouchMode="true"
+        android:clickable="false"
+        android:focusable="false"
         android:gravity="center_horizontal"
+        android:minHeight="@dimen/cb_target_min"
         android:orientation="vertical"
-        android:padding="8dp">
+        android:padding="@dimen/cb_card_padding">
 
         <ImageView
             android:id="@+id/wp_image"
             android:layout_width="match_parent"
-            android:layout_height="110dp"
+            android:layout_height="@dimen/cb_wp_thumb"
             android:contentDescription="@null"
+            android:importantForAccessibility="no"
             android:scaleType="centerCrop" />
 
         <TextView
             android:id="@+id/wp_name"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
+            android:layout_marginTop="@dimen/cb_space_sm"
             android:ellipsize="end"
             android:gravity="center"
             android:maxLines="1"
             android:textColor="@color/cb_ink"
-            android:textSize="12sp"
+            android:textSize="@dimen/cb_text_label"
             android:textStyle="bold" />
     </LinearLayout>
 
-    <!-- Selection-mode ring + check. Drawn on top; visibility toggled by the adapter. -->
     <View
         android:id="@+id/wp_selected_ring"
         android:layout_width="match_parent"

--- a/pop/src/main/res/layout/item_wallpaper.xml
+++ b/pop/src/main/res/layout/item_wallpaper.xml
@@ -4,25 +4,30 @@
   treatment as item_icon (Brand Guide §05). In selection mode a cyan frame
   marks chosen tiles.
 
-  No android:foreground ripple here. It pointed at
-  ?android:attr/selectableItemBackground, which resolves to the platform's grey
-  highlight — the only off-palette colour in the app — and it sat on this
-  FrameLayout while the focus ring is drawn on the inner card, so press and
-  focus highlighted two different rectangles. Press feedback now comes from the
-  theme's colorControlHighlight, in brand cyan, on the same surface as focus.
+  The ROOT is the focusable card. A previous revision put clickable/focusable
+  + bg_card on the inner LinearLayout and the click listener on this
+  FrameLayout, so D-pad highlight and OK landed on two different views —
+  the cyan ring never tracked the focused tile, and centre-press did nothing.
+  Press feedback comes from the theme's colorControlHighlight, in brand cyan,
+  on the same surface as focus. No platform selectableItemBackground: that
+  resolves to the grey highlight, the only off-palette colour in the app.
 -->
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:background="@drawable/bg_card"
+    android:clickable="true"
+    android:descendantFocusability="blocksDescendants"
+    android:focusable="true"
+    android:focusableInTouchMode="true"
+    android:minHeight="@dimen/cb_target_min"
     android:padding="0dp">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@drawable/bg_card"
-        android:clickable="true"
-        android:focusable="true"
-        android:focusableInTouchMode="true"
+        android:clickable="false"
+        android:focusable="false"
         android:gravity="center_horizontal"
         android:minHeight="@dimen/cb_target_min"
         android:orientation="vertical"

--- a/tests/test_wallpaper_export.py
+++ b/tests/test_wallpaper_export.py
@@ -78,6 +78,23 @@ class ResourceTests(unittest.TestCase):
         xml = read("app/src/main/res/layout/item_wallpaper.xml")
         self.assertIn("wp_selected_ring", xml)
 
+    def test_item_wallpaper_root_is_the_focus_target(self):
+        """D-pad highlight and OK must land on the same view as the click
+        listener (itemView). Nested focusable cards split those two, so the
+        cyan ring never tracked the focused tile and centre-press did nothing.
+        """
+        ns = "{http://schemas.android.com/apk/res/android}"
+        root = ET.fromstring(read("app/src/main/res/layout/item_wallpaper.xml"))
+        self.assertEqual(root.get(ns + "focusable"), "true", "root must be focusable")
+        self.assertEqual(root.get(ns + "clickable"), "true", "root must be clickable")
+        self.assertEqual(root.get(ns + "background"), "@drawable/bg_card")
+        self.assertEqual(root.get(ns + "descendantFocusability"), "blocksDescendants")
+        nested = [
+            el for el in root.iter()
+            if el is not root and el.get(ns + "focusable") == "true"
+        ]
+        self.assertEqual(nested, [], "nested focusable views steal D-pad highlight")
+
 
 class KotlinWiringTests(unittest.TestCase):
     def setUp(self):
@@ -180,6 +197,25 @@ class KotlinWiringTests(unittest.TestCase):
         self.assertIn("selectionMode", src)
         # onBackPressed should exit selection instead of finishing when in mode.
         self.assertRegex(src, r"if\s*\(adapter\.selectionMode\)")
+
+    def test_wallpaper_chips_keep_focus_on_pick(self):
+        """notifyDataSetChanged on a chip press drops D-pad highlight — the
+        exact bug ChipAdapter already documents. Targeted notifyItemChanged
+        keeps the focused chip attached.
+        """
+        src = self.files["WallpaperChipAdapter.kt"]
+        no_block = re.sub(r"/\*.*?\*/", "", src, flags=re.DOTALL)
+        code = "\n".join(line.split("//", 1)[0] for line in no_block.splitlines())
+        self.assertNotIn("notifyDataSetChanged()", code)
+        self.assertIn("notifyItemChanged", code)
+        self.assertIn("isSelected", code)
+        self.assertIn("KEYCODE_DPAD_LEFT", code)
+        self.assertIn("wp_grid", code)
+
+    def test_wallpaper_tile_requests_item_focus(self):
+        src = self.files["WallpaperAdapter.kt"]
+        self.assertIn("itemView.isFocusable = true", src)
+        self.assertIn("setOnFocusChangeListener", src)
 
 
 class VersionTests(unittest.TestCase):


### PR DESCRIPTION
## App

- [x] Icon pack
- [x] Pixel Neon icon pack
- [ ] Core Line
- [ ] Core Shift
- [ ] Core Doctor
- [ ] Core Motion
- [x] Docs / CI / suite

## Why this exists

The wallpaper browser's D-pad highlight does not stick, and OK on a tile often does nothing. Two independent splits:

1. **Series chips** — `WallpaperChipAdapter` called `notifyDataSetChanged()` on every press. That is the exact bug `ChipAdapter` already documents: a full rebind drops focus from the chip the user just pressed, so the highlight vanishes on the key that was supposed to move it.
2. **Tiles** — `bg_card` + `focusable` lived on an inner LinearLayout, while the click/long-press listener was on the FrameLayout `itemView`. D-pad highlight and centre-press landed on two different views. Pixel Neon also still used the platform grey `selectableItemBackground`.

`item_chip.xml` is shared with the icon grid and points `nextFocus` at `apply_button` / `grid`, which do not exist on the wallpaper screen.

## What changed (name the number)

**1. WallpaperChipAdapter** (Classic + Pixel Neon)
- Targeted `notifyItemChanged` instead of a full rebind
- `isSelected` + `isActivated`, D-pad left/right, focus scale — same contract as `ChipAdapter`
- Override `nextFocusUp`/`nextFocusDown` to `wp_selection_bar` / `wp_grid` (GONE bar collapses to Back via the #98 chain)

**2. item_wallpaper.xml** (Classic, Pop mirror, Pixel Neon)
- Root FrameLayout is the focusable card with `bg_card`
- Inner LinearLayout is not focusable/clickable
- `descendantFocusability="blocksDescendants"` so the overlay ring cannot steal focus
- Pixel Neon drops `?android:attr/selectableItemBackground`

**3. WallpaperAdapter** (Classic + Pixel Neon)
- `itemView.isFocusable = true` and the same scale/elevation lift the icon grid uses

**4. Tests** — root is the focus target, chips must not `notifyDataSetChanged()`, adapter requests item focus.

No catalog, artwork, or version bump. Independent of #100.

## Verification

- [x] `python tests/test_wallpaper_export.py` — 25 passed
- [x] `python tests/test_wallpapers.py` — 21 passed
- [x] `python tools/check_ui_resources.py` — OK, no stranded focusable
- [x] `python tools/check_suite_truth.py` — passed
- [x] Pop `item_wallpaper.xml` byte-identical to Classic (MirrorTests)
- [ ] On-device D-pad confirmation — no Android SDK here. Worth checking: chip highlight stays on press, Down from chips lands on a tile with a cyan ring, OK opens preview, long-press still shows the selection ring *and* the focus ring.

## Notes / unverified

Pixel Neon's *icon* chips (`ChipAdapter`) still use `notifyDataSetChanged()` — same class of bug on the main grid, not the wallpaper screen, left out of this PR on purpose.
